### PR TITLE
feat:created job doctype

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job/job.js
+++ b/fosa_connect/fosa_connect/doctype/job/job.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Job', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/fosa_connect/fosa_connect/doctype/job/job.json
+++ b/fosa_connect/fosa_connect/doctype/job/job.json
@@ -1,0 +1,130 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "ID.#####",
+ "creation": "2023-08-31 17:07:06.755179",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "job_title",
+  "qualification",
+  "responsibility",
+  "job_description",
+  "column_break_lzsug",
+  "job_category",
+  "location",
+  "job_type",
+  "salary_info",
+  "last_date_to_apply",
+  "section_break_ixlfp"
+ ],
+ "fields": [
+  {
+   "fieldname": "job_title",
+   "fieldtype": "Data",
+   "label": "Job Title",
+   "unique": 1
+  },
+  {
+   "fieldname": "location",
+   "fieldtype": "Data",
+   "label": "Location"
+  },
+  {
+   "fieldname": "salary_info",
+   "fieldtype": "Data",
+   "label": "Salary Info."
+  },
+  {
+   "fieldname": "job_description",
+   "fieldtype": "Long Text",
+   "label": "Job Description"
+  },
+  {
+   "fieldname": "last_date_to_apply",
+   "fieldtype": "Date",
+   "label": "Last date to apply"
+  },
+  {
+   "fieldname": "job_category",
+   "fieldtype": "Link",
+   "label": "Job Category",
+   "options": "Job Category"
+  },
+  {
+   "fieldname": "column_break_lzsug",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_ixlfp",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "qualification",
+   "fieldtype": "Link",
+   "label": "Qualification",
+   "options": "Qualification"
+  },
+  {
+   "fieldname": "responsibility",
+   "fieldtype": "Data",
+   "label": "Responsibility"
+  },
+  {
+   "fieldname": "job_type",
+   "fieldtype": "Select",
+   "label": "Job Type",
+   "options": "Full\nPart"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2023-09-02 15:18:18.504092",
+ "modified_by": "Administrator",
+ "module": "FOSA Connect",
+ "name": "Job",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Alumni",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Student",
+   "share": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/fosa_connect/fosa_connect/doctype/job/job.py
+++ b/fosa_connect/fosa_connect/doctype/job/job.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class Job(Document):
+	pass

--- a/fosa_connect/fosa_connect/doctype/job/test_job.py
+++ b/fosa_connect/fosa_connect/doctype/job/test_job.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestJob(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Feature description
Created Job Doctype

## Analysis and design (optional)
job doctype design


## Solution description
create the job doctype which include fields job title,job category,location,last date to apply,qualification,job type,salary info.

## Output screenshots
![Screenshot from 2023-09-02 15-54-12](https://github.com/efeone/fosa_connect/assets/84180042/cb6ea533-e8e7-4ec9-a12b-e352e1edca48)
![Screenshot from 2023-09-02 16-00-02](https://github.com/efeone/fosa_connect/assets/84180042/d58010cd-d39f-4248-b780-b435cd6429dc)

## Is there any existing behavior change of other features due to this code change?
yes

## Was this feature tested on the browsers?
  - Chrome
