### PR TITLE
fix:Modification of Interest Button in Job Doctype

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job/job.js
+++ b/fosa_connect/fosa_connect/doctype/job/job.js
@@ -1,18 +1,26 @@
 frappe.ui.form.on('Job', {
   refresh: function (frm) {
-    var liked_user_list = JSON.parse(frm.doc._liked_by)
+    if (frappe.user_roles.includes('Student')){
+    if (!frm.is_new()){
 
-    // Checking if the logged in user has liked the job
-    if (!liked_user_list.includes(frappe.session.user)){
+      var liked_user_list = []
+      
+      if (frm.doc._liked_by) {
+        liked_user_list = JSON.parse(frm.doc._liked_by)}
 
-      frm.add_custom_button(('Interested'), function () {
-        interest_button_fn(frm, `Yes`)
-      });
+      // Checking if the logged in user has liked the job
+      if (!liked_user_list.includes(frappe.session.user)){
+
+        frm.add_custom_button(('Interested'), function () {
+          interest_button_fn(frm, `Yes`)
+        });
+      }
+      else {
+        frm.add_custom_button('Not Interested', function () {
+          interest_button_fn(frm, `No`)
+        });
+      }
     }
-    else {
-      frm.add_custom_button('Not Interested', function () {
-        interest_button_fn(frm, `No`)
-      });
     }
   }
   


### PR DESCRIPTION
## Feature description
Modification of Interest Button in Job Doctype(will appear only after saving the job form,only student will be able to use the Interest button)

## Analysis and design (issues)
1.Interest button was working even before saving the Job. 
2.Both student and alumni were able to use the Interest Button.

## Solution description
1.if (!frm.is_new()) {  }:Used this ,so that interest button only appears when the form is saved.
2.if (frappe.user_roles.includes('Student')) { }:Used this ,so that students can only use the interest button.

## Output screenshots 
![image](https://github.com/efeone/fosa_connect/assets/98837574/90abece1-51a6-4d64-ac07-ea5fd6e81c29)
![image](https://github.com/efeone/fosa_connect/assets/98837574/2e7e11fc-aad7-4ac4-88c0-0b42d2b500c4)



## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 