### PR TITLE
fix:Code errors in signup form

### DIFF
--- a/fosa_connect/templates/signup.html
+++ b/fosa_connect/templates/signup.html
@@ -2,6 +2,7 @@
     <div class="page-card-body">
         <label for="member_type">Select Member Type:</label>
         <select id="member_type" name="member_type" required style="width: 50%; padding: 7px; border: none; border-radius: 4px;">
+            <option value="null" id="nullOption"></option>
             <option value="student">Student</option>
             <option value="alumni">Alumni</option>
         </select><br><br>
@@ -68,10 +69,12 @@
 
 
 <script>
-  document.getElementById('student_fields').style.display = 'none';
+        document.getElementById("nullOption").selected = true;
+        document.getElementById('student_fields').style.display = 'none';
         document.getElementById('alumni_fields').style.display = 'none';
 
   document.getElementById('member_type').addEventListener('change', function() {
+
           if (this.value === 'student') {
               document.getElementById('student_fields').style.display = 'block';
               document.getElementById('alumni_fields').style.display = 'none';


### PR DESCRIPTION
## Feature description
fixed code errors in the signup form template

## Solution description
code changed in the script of signup.html. When reloading the page the member type will shows null.

## Output screenshots 
![Screenshot from 2023-09-07 12-22-23](https://github.com/efeone/fosa_connect/assets/84098652/18546425-f93c-4feb-9ac5-10ac6488f621)
![Screenshot from 2023-09-07 12-22-48](https://github.com/efeone/fosa_connect/assets/84098652/c63742a2-1f11-42d9-8af2-5118e1eed161)
![Screenshot from 2023-09-07 12-23-05](https://github.com/efeone/fosa_connect/assets/84098652/bf8b7812-6c99-4c34-b5a3-cf33a958ffd8)

## Areas affected and ensured
The signup.html in the template is affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome