### PR TITLE
feat:Added Button to Member DocType to create CV

### DIFF
--- a/fosa_connect/fosa_connect/doctype/member/member.js
+++ b/fosa_connect/fosa_connect/doctype/member/member.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on('Member', {
     setup: function(frm) {
+        // Filter addresses to show only address linked to the current user
         frm.set_query('primary_address', function(doc) {
 			return {
 				filters: {
@@ -13,8 +14,14 @@ frappe.ui.form.on('Member', {
 		})
     },
 	 refresh: function(frm) {
-        frappe.dynamic_link = {doc: frm.doc, fieldname: 'name', doctype: 'Member'}
+        //Create CV Button
+        frm.add_custom_button(('Create CV'), function () {
+        frappe.set_route('print', frm.doc.doctype, frm.doc.name)
+        });
 
+        //Dynamic Link to link member to their new address
+        frappe.dynamic_link = {doc: frm.doc, fieldname: 'name', doctype: 'Member'}
+        //New address
         if(!frm.doc.__islocal) {
 			frappe.contacts.render_address_and_contact(frm);
         } else {


### PR DESCRIPTION
## Feature description
Added Custom button in Member Doctype

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Created a Custom button named  'Create CV'  for the user to easily navigate to create cv / access print format page

## Output screenshots 
![Screenshot from 2023-09-07 16-32-43](https://github.com/efeone/fosa_connect/assets/59536246/068cfea8-2def-4676-9b58-882a74f9da89)


## Areas affected and ensured
Member Documents

## Was this feature tested on the browsers?
  - Mozilla Firefox