### PR TITLE
feat:web view of job doctype

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job/job.json
+++ b/fosa_connect/fosa_connect/doctype/job/job.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_guest_to_view": 1,
  "allow_rename": 1,
  "autoname": "ID.#####",
  "creation": "2023-08-31 17:07:06.755179",
@@ -15,12 +16,13 @@
   "start_date",
   "job_description",
   "column_break_lzsug",
-  "is_published",
+  "published",
   "job_category",
   "location",
   "job_type",
   "last_date_to_apply",
-  "salary_info"
+  "salary_info",
+  "route"
  ],
  "fields": [
   {
@@ -28,8 +30,7 @@
    "fieldname": "job_title",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Job Title",
-   "unique": 1
+   "label": "Job Title"
   },
   {
    "columns": 2,
@@ -88,25 +89,33 @@
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled",
-   "read_only_depends_on": "eval:doc.is_published"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_published",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Is Published",
-   "read_only_depends_on": "eval:doc.disabled"
+   "permlevel": 1,
+   "read_only_depends_on": "eval:doc.published"
   },
   {
    "fieldname": "start_date",
    "fieldtype": "Date",
    "label": "Start date"
+  },
+  {
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "label": "Route"
+  },
+  {
+   "default": "0",
+   "fieldname": "published",
+   "fieldtype": "Check",
+   "label": "Is Published",
+   "permlevel": 1,
+   "read_only_depends_on": "eval:doc.disabled"
   }
  ],
+ "has_web_view": 1,
  "index_web_pages_for_search": 1,
+ "is_published_field": "published",
  "links": [],
- "modified": "2023-09-04 14:44:18.753546",
+ "modified": "2023-09-11 15:04:08.615234",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Job",
@@ -142,6 +151,18 @@
   {
    "email": 1,
    "export": 1,
+   "if_owner": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Alumni",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
    "print": 1,
    "read": 1,
    "report": 1,
@@ -151,6 +172,7 @@
   }
  ],
  "quick_entry": 1,
+ "route": "Job",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/fosa_connect/fosa_connect/doctype/job/templates/job.html
+++ b/fosa_connect/fosa_connect/doctype/job/templates/job.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{doc.job_title}}</title>
+    <style>
+        body {
+          width: 100%;
+          height: 100vh;
+          background-color: #f2f2f2;
+          margin: 0;
+          padding: 0;
+          justify-content: center;
+          align-items: center;
+          display: flex;
+          font-family: sans-serif;
+        }
+        .container {
+          background-color:#f2f2f2;
+       width: 750px;
+       overflow: hidden;
+       border-radius: 20px;
+       padding: 15px 20px 10px 20px;
+       box-shadow: 13px 13px 13px rgb(230, 230, 230),
+                   -13px -13px 13px 	rgb(255, 255, 255);
+        }
+        h1 {
+            color: black;
+            font-size: 28px;
+        }
+        h2 {
+            color: #333;
+            font-size: 24px;
+        }
+        p {
+            color: #666;
+            font-size: 16px;
+        }
+        .category {
+            color: #333;
+        }
+        .published_date {
+          color: #e67e22;
+          }
+          .end_date {
+            color: #e67e22;
+            }
+        .location {
+            color: #e67e22;
+        }
+        .responsibilities {
+            margin-top: 10px;
+        }
+        .description {
+            margin-top: 20px;
+        }
+        .apply-button {
+            text-align: center;
+            margin-top: 20px;
+          }
+        .btn {
+            background-color: green;
+            color: white;
+            padding: 10px 20px;
+            border: none;
+            cursor: pointer;
+        }
+        .btn:hover {
+            background-color:green;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>{{doc.job_title}}</h1>
+        <h2>Job Category: <span class="category">{{doc.job_category}}</span></h2>
+        <hr>
+        <p class="published_date">Published Date: {{doc.start_date.strftime('%d-%m-%Y')}}</p>
+        <p class="location">Location: {{doc.location}}</p>
+        <p><strong>Job Type:</strong> {{doc.job_type}}</p>
+        <p><strong>Job Description:</strong>{{doc.job_description}}</p>
+        <p><strong>Responsibilities:</strong>{{doc.responsibility}}</p>
+        <p><strong>Qualifications:</strong>{{doc.qualification}}</p>
+        <p><strong>Salary Info.:</strong> {{doc.salary_info}}</p>
+        <p class="end_date">Last Date to apply:</strong> {{doc.last_date_to_apply.strftime('%d-%m-%Y')}}</p>
+        <p>If you are interested in this position, please Click On intrested </a>.</p>
+        <div class="apply-button">
+            <button class="btn" id="interestButton" onclick="toggleInterest()">I'm Interested</button>
+        </div>
+
+        <!-- <div class="responsibilities">
+            <h3>Responsibilities:</h3>
+            <ul>
+                <li>Develop and maintain web applications</li>
+                <li>Collaborate with the design team</li>
+                <li>Implement responsive designs</li>
+                <!-- Add more responsibilities as needed -->
+        </div> -->
+
+        <!-- Add more sections as needed -->
+    </div>
+    <script>
+          let isInterested = true; // Initial state is "Interested"
+
+          function toggleInterest() {
+              const interestButton = document.getElementById("interestButton");
+
+              if (isInterested) {
+                  interestButton.textContent = "Not Interested";
+                  interestButton.style.backgroundColor = "#e74c3c"; // Change button color
+              } else {
+                  interestButton.textContent = "I'm Interested";
+                  interestButton.style.backgroundColor = "green"; // Change button color back
+              }
+
+              isInterested = !isInterested; // Toggle the state
+          }
+      </script>
+</body>
+</html>

--- a/fosa_connect/fosa_connect/doctype/job/templates/job_row.html
+++ b/fosa_connect/fosa_connect/doctype/job/templates/job_row.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Job List</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #ADD8E6;
+            margin: 0;
+            padding: 0;
+        }
+        .job-list {
+                    max-width: 800px;
+                    margin: 20px auto;
+                    background-color: #ADD8E6;
+                    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+                    border-radius: 10px;
+                    padding: 20px;
+                }
+
+                .job {
+                    border: 1px solid #ddd;
+                    padding: 20px;
+                    margin-bottom: 20px;
+                    background-color: #fff;
+                    border-radius: 10px;
+                    transition: background-color 0.3s ease;
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                }
+                .font-size-lg {
+           font-size: 24px;
+           color: #333;
+           margin: 0;
+           text-decoration: none;
+       }
+
+       .font-size-lg:hover {
+           color: #007BFF;
+       }
+
+       .text-muted {
+           color: #666;
+           margin-top: 5px;
+       }
+       .apply-button {
+            background-color: #007BFF;
+            color: #fff;
+            padding: 10px 20px;
+            text-decoration: none;
+            border-radius: 5px;
+            transition: background-color 0.3s ease;
+        }
+
+        .apply-button:hover {
+            background-color: #0056b3;
+        }
+    </style>
+</head>
+<body>
+  <div class="job-list">
+      <div class="job">
+          <div class="col">
+              <a class="font-size-lg">{{ doc.job_title }}</a>
+              <p class="text-muted">Location: {{ doc.location }}</p>
+              <p class="text-muted">Last Date to Apply: {{ doc.last_date_to_apply }}</p>
+              <p class="text-muted">{{ doc.job_description }}</p>
+          </div>
+          <a href="{{ doc.route }}" class="apply-button">View details</a>
+      </div>
+  </div>
+</body>
+</html>

--- a/fosa_connect/fosa_connect/doctype/job_category/job_category.json
+++ b/fosa_connect/fosa_connect/doctype/job_category/job_category.json
@@ -22,7 +22,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-01 15:12:38.143996",
+ "modified": "2023-09-11 15:12:33.744682",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Job Category",
@@ -40,6 +40,15 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Alumni",
+   "share": 1
   }
  ],
  "quick_entry": 1,

--- a/fosa_connect/fosa_connect/doctype/qualification/qualification.json
+++ b/fosa_connect/fosa_connect/doctype/qualification/qualification.json
@@ -22,7 +22,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-01 15:12:20.253741",
+ "modified": "2023-09-11 15:13:17.899617",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Qualification",
@@ -40,6 +40,15 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Alumni",
+   "share": 1
   }
  ],
  "quick_entry": 1,


### PR DESCRIPTION
## Feature description
Create the web view of Job Doctype.
Student cannot view the disabled and is published field.


## Solution description
Disabled and is published is hidden from the student. but alumni can view this.

## Output screenshots (optional)
![Screenshot from 2023-09-11 10-54-35](https://github.com/efeone/fosa_connect/assets/84180042/2b9a6513-3c19-4f4a-800e-fc782daa3d4c)
![Screenshot from 2023-09-11 10-50-13](https://github.com/efeone/fosa_connect/assets/84180042/bbe34eca-e8e1-4749-8323-3c9143e1c50d)
![Screenshot from 2023-09-11 10-48-56](https://github.com/efeone/fosa_connect/assets/84180042/b3ea87c8-4a90-426f-a717-589d25cbbb62)


## Areas affected and ensured
web view

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
 
