### PR TITLE
feat: hide to_date when current checked

### DIFF
--- a/fosa_connect/fosa_connect/doctype/career_history/career_history.json
+++ b/fosa_connect/fosa_connect/doctype/career_history/career_history.json
@@ -84,7 +84,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-09-05 15:36:08.915084",
+ "modified": "2023-09-12 15:34:49.077172",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Career History",

--- a/fosa_connect/fosa_connect/doctype/member/member.js
+++ b/fosa_connect/fosa_connect/doctype/member/member.js
@@ -31,8 +31,22 @@ frappe.ui.form.on('Member', {
         if(!frm.is_new()){
         frm.set_df_property('primary_address', 'reqd', 1)
         }
+        var currentCheckbox = frm.doc.current;
+        var toField = frm.get_field('to'); // Assuming 'to' is the fieldname
+
+        if (currentCheckbox) {
+            toField.$wrapper.hide(); // Hide the 'to' field
+            toField.set_value(''); // Clear the 'to' field value
+        } else {
+            toField.$wrapper.show(); // Show the 'to' field
+        }
+
+        // Set 'to' field as required when not a new record
+        if (!frm.is_new()) {
+            frm.set_df_property('to', 'reqd', 1);
+        }
 	 },
-    
+
 	validate: function (frm) {
         if(frm.doc.status == 'Student'){
         var year = frm.doc.year_of_admission;


### PR DESCRIPTION
## Feature description
to_date value is clear and hide when current checked.
make image field is mandatory
make Education Child table is mandatory

## Solution description
code added in member.js for hide to_date when current checked.

## Output screenshots (optional)
[Screencast from 12-09-23 04:32:17 PM IST.webm](https://github.com/efeone/fosa_connect/assets/84180042/b0920c31-7e1f-4002-9d39-ca98d6ccc30e)
![Screenshot from 2023-09-12 16-35-04](https://github.com/efeone/fosa_connect/assets/84180042/28dfc9f1-a782-41b7-8198-216ffc66daba)


## Areas affected and ensured
Member DocType

## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome
  
