### PR TITLE
Alumni notification for Job Interest and fixtures for Program and Job

### DIFF
--- a/fosa_connect/fixtures/job_category.json
+++ b/fosa_connect/fixtures/job_category.json
@@ -1,0 +1,128 @@
+[
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Agriculture",
+  "modified": "2023-09-06 10:41:54.036710",
+  "name": "Agriculture"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Food",
+  "modified": "2023-09-06 10:42:14.277029",
+  "name": "Food"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Natural Resources",
+  "modified": "2023-09-06 10:42:29.118620",
+  "name": "Natural Resources"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Architecture",
+  "modified": "2023-09-06 10:42:45.266642",
+  "name": "Architecture"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Construction",
+  "modified": "2023-09-06 10:42:53.174224",
+  "name": "Construction"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Arts",
+  "modified": "2023-09-06 10:43:02.021368",
+  "name": "Arts"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Communications and Media",
+  "modified": "2023-09-06 10:51:55.156442",
+  "name": "Communications and Media"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Audio/Video Technology",
+  "modified": "2023-09-06 10:52:05.144155",
+  "name": "Audio/Video Technology"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Business and Finance",
+  "modified": "2023-09-06 11:05:27.323953",
+  "name": "Business and Finance"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Education and Training",
+  "modified": "2023-09-06 11:05:36.654780",
+  "name": "Education and Training"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Government and Public Administration",
+  "modified": "2023-09-06 11:05:54.562602",
+  "name": "Government and Public Administration"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Health Science",
+  "modified": "2023-09-06 11:06:03.931363",
+  "name": "Health Science"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Information Technology",
+  "modified": "2023-09-06 11:06:19.630698",
+  "name": "Information Technology"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Law",
+  "modified": "2023-09-06 11:06:46.239280",
+  "name": "Law"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Public Safety and Security",
+  "modified": "2023-09-06 11:07:06.346107",
+  "name": "Public Safety and Security"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Sales and Marketing",
+  "modified": "2023-09-06 11:07:13.027976",
+  "name": "Sales and Marketing"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Science and Technology",
+  "modified": "2023-09-06 11:12:13.173104",
+  "name": "Science and Technology"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Job Category",
+  "job_category": "Transportation",
+  "modified": "2023-09-06 11:15:28.598221",
+  "name": "Transportation"
+ }
+]

--- a/fosa_connect/fixtures/program.json
+++ b/fosa_connect/fixtures/program.json
@@ -1,0 +1,156 @@
+[
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:33:14.755995",
+  "name": "Department of Arabic and Islamic Study",
+  "program_name": "Department of Arabic and Islamic Study"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:33:23.879432",
+  "name": "Department of English",
+  "program_name": "Department of English"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:33:35.613837",
+  "name": "Department of Malayalam",
+  "program_name": "Department of Malayalam"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:34:16.112975",
+  "name": "Department of English(SF)",
+  "program_name": "Department of English(SF)"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:34:47.183586",
+  "name": "Department of Physics",
+  "program_name": "Department of Physics"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:34:58.760853",
+  "name": "Department of Chemistry",
+  "program_name": "Department of Chemistry"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:35:06.609944",
+  "name": "Department of Botony",
+  "program_name": "Department of Botony"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:35:16.586522",
+  "name": "Department of History",
+  "program_name": "Department of History"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:35:25.998270",
+  "name": "Department of Zoology",
+  "program_name": "Department of Zoology"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:35:36.916090",
+  "name": "Department of Geology",
+  "program_name": "Department of Geology"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:35:47.022397",
+  "name": "Department of Sociology",
+  "program_name": "Department of Sociology"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:36:00.371034",
+  "name": "Department of Psychology",
+  "program_name": "Department of Psychology"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:36:11.001717",
+  "name": "Department of psychology (SF)",
+  "program_name": "Department of psychology (SF)"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:36:20.491760",
+  "name": "Department of Economics",
+  "program_name": "Department of Economics"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:36:44.829535",
+  "name": "Department of Commerce and Management Study",
+  "program_name": "Department of Commerce and Management Study"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:39:36.478079",
+  "name": "Department  of Commerce (SF)",
+  "program_name": "Department  of Commerce (SF)"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:39:45.118444",
+  "name": "Department of Mathematics",
+  "program_name": "Department of Mathematics"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:40:01.782646",
+  "name": "Department of Statistics",
+  "program_name": "Department of Statistics"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:40:23.454733",
+  "name": "Department of Computer Science",
+  "program_name": "Department of Computer Science"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:40:33.586960",
+  "name": "Department of Software development (SF)",
+  "program_name": "Department of Software development (SF)"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:40:44.222192",
+  "name": "Department of Automobile(SF)",
+  "program_name": "Department of Automobile(SF)"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Program",
+  "modified": "2023-09-05 16:40:53.480897",
+  "name": "Department of Multimedia",
+  "program_name": "Department of Multimedia"
+ }
+]

--- a/fosa_connect/fosa_connect/doctype/job/job.js
+++ b/fosa_connect/fosa_connect/doctype/job/job.js
@@ -1,31 +1,29 @@
 frappe.ui.form.on('Job', {
   refresh: function (frm) {
-    if (frappe.user_roles.includes('Student')){
-    if (!frm.is_new()){
+    if (frappe.user_roles.includes('Student')) {
+      if (!frm.is_new()) {
 
-      var liked_user_list = []
-      
-      if (frm.doc._liked_by) {
-        liked_user_list = JSON.parse(frm.doc._liked_by)}
+        var liked_user_list = []
 
-      // Checking if the logged in user has liked the job
-      if (!liked_user_list.includes(frappe.session.user)){
+        if (frm.doc._liked_by) {
+          liked_user_list = JSON.parse(frm.doc._liked_by)
+        }
 
-        frm.add_custom_button(('Interested'), function () {
-          create_job_interest(frm)
-          interest_button_fn(frm, `Yes`)
-        });
+        // Checking if the logged in user has liked the job
+        if (!liked_user_list.includes(frappe.session.user)) {
+          frm.add_custom_button(('Interested'), function () {
+            create_job_interest(frm)
+            interest_button_fn(frm, `Yes`)
+          });
+        }
+        else {
+          frm.add_custom_button('Not Interested', function () {
+            interest_button_fn(frm, `No`)
+          });
+        }
       }
-      else {
-        frm.add_custom_button('Not Interested', function () {
-          interest_button_fn(frm, `No`)
-        });
-      }
-    }
     }
   }
-  
-  
 });
 
 function interest_button_fn(frm, add) {
@@ -46,21 +44,12 @@ function interest_button_fn(frm, add) {
 }
 
 function create_job_interest(frm) {
-// Create a new entry in the "Job Interest" DocType
+  // Create a new entry in the "Job Interest" DocType
   frappe.call({
     method: 'fosa_connect.fosa_connect.utils.create_job_interest_entry',
     args: {
-        job_id: frm.doc.name,
-        student_id: frappe.session.user
+      job_id: frm.doc.name,
+      student_id: frappe.session.user,
     },
-    callback: function(response) {
-        if (response.message === 'success') {
-            // Successfully created the "Job Interest" entry
-            frappe.msgprint('You have expressed interest in this job.');
-        } else {
-            // Handle any errors that occurred during the creation of the entry
-            frappe.msgprint('An error occurred while expressing interest in this job.');
-        }
-    }
   });
 }

--- a/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
+++ b/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
@@ -1,8 +1,25 @@
 # Copyright (c) 2023, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.website.website_generator import WebsiteGenerator
+from frappe.model.document import Document
+from fosa_connect.fosa_connect.utils import create_notification_log
 
 class JobInterest(WebsiteGenerator):
-	pass
+    pass
+
+
+class JobInterest(Document):
+    def after_insert(self):
+       if self.job:
+           recipient = frappe.db.get_value('Job', self.job, 'owner')
+           job_title = frappe.db.get_value('Job', self.job, 'job_title')
+           job_create_notification_log(self, recipient, job_title) 
+
+# Job Update for alumni
+@frappe.whitelist()
+def job_create_notification_log(doc, recipient, job_title):
+    subject = "New Job Interest for "+job_title
+    create_notification_log(doc, recipient, subject)
+    frappe.db.commit()

--- a/fosa_connect/fosa_connect/doctype/program/program.json
+++ b/fosa_connect/fosa_connect/doctype/program/program.json
@@ -16,14 +16,13 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Program Name",
-   "options": "Name",
    "reqd": 1,
    "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-01 16:44:41.242523",
+ "modified": "2023-09-08 13:21:37.519498",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Program",

--- a/fosa_connect/fosa_connect/utils.py
+++ b/fosa_connect/fosa_connect/utils.py
@@ -1,29 +1,48 @@
 import frappe
 
+
 @frappe.whitelist()
 def create_job_interest_entry(job_id, student_id):
     try:
         member = frappe.get_doc("Member", {"email_id": student_id})
         # Check if a job interest entry already exists for the student and job
-        existing_entry = frappe.get_list(
-            "Job Interest",
-            filters={"job": job_id, "member": member.name},
-        )
-        if not existing_entry:
+        if not frappe.db.exists("Job Interest", {"job": job_id, "member": member.name}):
             # Create a new entry in the "Job Interest" DocType
             job_interest = frappe.new_doc("Job Interest")
             job_interest.job = job_id
-            job_interest.member = member
+            job_interest.member = member.name
             job_interest.posting_date = frappe.utils.nowdate()
             job_interest.save()
 
             # Return a success message
-            return "success"
+            frappe.msgprint("You have expressed interest in this job.")
         else:
             # A job interest entry already exists, so return an error message
-            return "Entry already exists"
+            frappe.throw("Job Interest was already created once")
 
     except Exception as e:
         # Handle any exceptions or errors that may occur during the process
         frappe.log_error(f"Error creating job interest entry: {str(e)}")
         return "Error"
+
+
+# Notification Function
+@frappe.whitelist()
+def create_notification_log(doc, recipient, subject, content=None, type=None):
+    """method is used to create notification log
+    args:
+        doc: document object
+        recipient: notification receiving user
+        subject: subject of notification log
+        type: type of the notification log"""
+    notification_log = frappe.new_doc("Notification Log")
+    notification_log.type = "Alert"
+    if type:
+        notification_log.type = type
+    notification_log.document_type = doc.doctype
+    notification_log.document_name = doc.name
+    notification_log.for_user = recipient
+    notification_log.subject = subject
+    if content:
+        notification_log.email_content = content
+    notification_log.save(ignore_permissions=True)

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -217,3 +217,7 @@ signup_form_template = "fosa_connect/templates/signup.html"
 # auth_hooks = [
 #	"fosa_connect.auth.validate"
 # ]
+
+fixtures = [
+    "Program", "Job Category"
+]


### PR DESCRIPTION
## Feature description

- Created feature to implement notification for alumni
- Added fixtures for Program DocType and Job Category Doctype

## Solution description

- Alumni would now be notified when a student raises an interest for a particular job they posted.
- Default documents for Master DocTypes Program and Job Category has been added

## Output screenshots
[Screencast from 12-09-23 09:25:00 PM IST.webm](https://github.com/efeone/fosa_connect/assets/59536246/fb41b06d-a96c-4819-a1fa-cec070e1fdbe)

![image](https://github.com/efeone/fosa_connect/assets/59536246/a4aad731-3e15-416c-9475-5a14e2c057c1)
![image](https://github.com/efeone/fosa_connect/assets/59536246/43d6ce80-33da-41ce-8702-8f5853e48187)

## Areas affected and ensured
Notification

## Is there any existing behavior change of other features due to this code change?
Yes, Revelant link fields would get additional options to choose from.

## Was this feature tested on the browsers?
  - Mozilla Firefox
