### PR TITLE
fix:modify date format and hide fields in webview

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job/job.json
+++ b/fosa_connect/fosa_connect/doctype/job/job.json
@@ -30,14 +30,16 @@
    "fieldname": "job_title",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Job Title"
+   "label": "Job Title",
+   "reqd": 1
   },
   {
    "columns": 2,
    "fieldname": "location",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Location"
+   "label": "Location",
+   "reqd": 1
   },
   {
    "fieldname": "salary_info",
@@ -47,7 +49,8 @@
   {
    "fieldname": "job_description",
    "fieldtype": "Long Text",
-   "label": "Job Description"
+   "label": "Job Description",
+   "reqd": 1
   },
   {
    "fieldname": "last_date_to_apply",
@@ -61,7 +64,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Job Category",
-   "options": "Job Category"
+   "options": "Job Category",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_lzsug",
@@ -71,12 +75,14 @@
    "fieldname": "qualification",
    "fieldtype": "Link",
    "label": "Qualification",
-   "options": "Qualification"
+   "options": "Qualification",
+   "reqd": 1
   },
   {
    "fieldname": "responsibility",
    "fieldtype": "Data",
-   "label": "Responsibility"
+   "label": "Responsibility",
+   "reqd": 1
   },
   {
    "fieldname": "job_type",
@@ -114,7 +120,7 @@
  "has_web_view": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2023-09-13 09:48:06.108349",
+ "modified": "2023-09-13 14:23:51.905285",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Job",

--- a/fosa_connect/fosa_connect/doctype/job/templates/job.html
+++ b/fosa_connect/fosa_connect/doctype/job/templates/job.html
@@ -76,14 +76,20 @@
         <h1>{{doc.job_title}}</h1>
         <h2>Job Category: <span class="category">{{doc.job_category}}</span></h2>
         <hr>
-        <p class="published_date">Published Date: {{doc.start_date}}</p>
-        <p class="location">Location: {{doc.location}}</p>
+        {% if doc.start_date %}
+        <p class="published_date">Published Date:</strong> {{doc.get_formatted("start_date")}}</p>
+         {% endif %}
+        <p class="location" style="margin-top:-23px">Location: {{doc.location}}</p>
         <p><strong>Job Type:</strong> {{doc.job_type}}</p>
         <p><strong>Job Description:</strong>{{doc.job_description}}</p>
         <p><strong>Responsibilities:</strong>{{doc.responsibility}}</p>
         <p><strong>Qualifications:</strong>{{doc.qualification}}</p>
+        {% if doc.salary_info %}
         <p><strong>Salary Info.:</strong> {{doc.salary_info}}</p>
-        <p class="end_date">Last Date to apply:</strong> {{doc.last_date_to_apply}}</p>
+        {% endif %}
+          {% if doc.last_date_to_apply %}
+        <p class="end_date">Last Date to apply:</strong> {{doc.get_formatted("last_date_to_apply")}}</p>
+        {% endif %}
         <p>If you are interested in this position, please Click On intrested </a>.</p>
         <div class="apply-button">
             <button class="btn" id="interestButton" onclick="toggleInterest()">I'm Interested</button>


### PR DESCRIPTION
## Feature description
Correct the format of published date and last date to apply in web view of job.
Hide the field in web view which has not given the values.
Make Mandatory some fields in Job doctype include job title,job category,location,responsibility.Alumni should fill the fields so students get basic information about jobs.

## Solution description
In job.html file add the code to hide the fields and give format of date

## Output screenshots (optional)
![Screenshot from 2023-09-13 15-45-26](https://github.com/efeone/fosa_connect/assets/84180042/d7689d72-0263-4a1b-83b6-10beb63b71f7)


## Areas affected and ensured
web view

## Is there any existing behavior change of other features due to this code change?
No. 
## Was this feature tested on the browsers?
  - Chrome
 
