### PR TITLE
feat:Only published job can be viewed by student.Not be viewed if it …

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job/job.py
+++ b/fosa_connect/fosa_connect/doctype/job/job.py
@@ -1,8 +1,24 @@
 # Copyright (c) 2023, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class Job(Document):
 	pass
+
+
+
+@frappe.whitelist()
+def permission_query_conditions(user):
+	if not user:
+		user = frappe.session.user
+	user_roles = frappe.get_roles(user)
+	if user == "Administrator" in user_roles:
+		return None
+
+	if "Student" in user_roles:
+		conditions = """tabJob.published = 1"""
+		return conditions
+
+	return None  # Return None for other roles

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -100,9 +100,9 @@ signup_form_template = "fosa_connect/templates/signup.html"
 # -----------
 # Permissions evaluated in scripted ways
 
-# permission_query_conditions = {
-#	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
-# }
+permission_query_conditions = {
+	"Job": "fosa_connect.fosa_connect.doctype.job.job.permission_query_conditions",
+}
 #
 # has_permission = {
 #	"Event": "frappe.desk.doctype.event.event.has_permission",


### PR DESCRIPTION
…was disabled job

## Feature description
When student login then they can be viewed only the published job. if the job is disabled then students cant be viewed until it is change to published.
![Screenshot from 2023-09-13 16-00-44](https://github.com/efeone/fosa_connect/assets/133144039/d2e64750-4c35-4919-a867-c14475252cc8)




## Is there any existing behavior change of other features due to this code change?
  No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
## Output screenshots (optional)
