### PR TITLE
fix:Code error in the job_interest.py file of Job Interest doctype

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job_interest/job_interest.json
+++ b/fosa_connect/fosa_connect/doctype/job_interest/job_interest.json
@@ -59,7 +59,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2023-09-07 17:05:16.733794",
+ "modified": "2023-09-13 15:09:45.063766",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Job Interest",
@@ -102,7 +102,7 @@
   }
  ],
  "quick_entry": 1,
- "route": "job",
+ "route": "job-interest",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
+++ b/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
@@ -10,32 +10,21 @@ from fosa_connect.fosa_connect.utils import create_notification_log
 class JobInterest(WebsiteGenerator):
     pass
 
-
-class JobInterest(Document):
-    def after_insert(self):
-        if self.job:
-            recipient = frappe.db.get_value("Job", self.job, "owner")
-            job_title = frappe.db.get_value("Job", self.job, "job_title")
-            job_create_notification_log(self, recipient, job_title)
-
-    def on_update(self):
-        if self.status != "Open":
-            recipient = frappe.db.get_value("Member", self.member, "email_id")
-            job_title = frappe.db.get_value("Job", self.job, "job_title")
-            student_notification_log(self, recipient, job_title, self.status)
-
-
 # Job Update for alumni
 @frappe.whitelist()
-def job_create_notification_log(doc, recipient, job_title):
-    subject = "New Job Interest for " + job_title
-    create_notification_log(doc, recipient, subject)
-    frappe.db.commit()
+def job_create_notification_log(doc, method=None):
+    if doc.job:
+        recipient = frappe.db.get_value("Job", doc.job, "owner")
+        job_title = frappe.db.get_value("Job", doc.job, "job_title")
+        subject = "New Job Interest for " + job_title
+        create_notification_log(doc, recipient, subject)
 
 
 # Job Update for student
 @frappe.whitelist()
-def student_notification_log(doc, recipient, job_title, status):
-    subject = "Job Interest update for " + job_title + " : " + status
-    create_notification_log(doc, recipient, subject)
-    frappe.db.commit()
+def student_notification_log(doc, method=None):
+    if doc.status != "Open":
+        recipient = frappe.db.get_value("Member", doc.member, "email_id")
+        job_title = frappe.db.get_value("Job", doc.job, "job_title")
+        subject = "Job Interest update for " + job_title + " : " + doc.status
+        create_notification_log(doc, recipient, subject)

--- a/fosa_connect/fosa_connect/doctype/member/member.json
+++ b/fosa_connect/fosa_connect/doctype/member/member.json
@@ -267,7 +267,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-05 13:07:17.956625",
+ "modified": "2023-09-13 15:21:02.523468",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Member",
@@ -283,6 +283,30 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Student",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Alumni",
    "share": 1,
    "write": 1
   }

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -120,13 +120,12 @@ signup_form_template = "fosa_connect/templates/signup.html"
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-#	"*": {
-#		"on_update": "method",
-#		"on_cancel": "method",
-#		"on_trash": "method"
-#	}
-# }
+doc_events = {
+    "Job Interest": {
+        "after_insert": "fosa_connect.fosa_connect.doctype.job_interest.job_interest.job_create_notification_log",
+        "on_update": "fosa_connect.fosa_connect.doctype.job_interest.job_interest.student_notification_log"
+    }
+}
 
 # Scheduled Tasks
 # ---------------


### PR DESCRIPTION
## Feature description
Modified the code in the job_interest.py file. Also added doc_events in hooks.py for the working of notification. Added Permission to Alumni and Student to access member doctype and address,contact and program doctypes.

## Analysis and design
The web view of job interest doctype was unable to access due to the codes of notification was in a document class along with the websiteGenerator class.

## Solution description
The document class is removed and the function inside the class written as:
@frappe.whitelist()
function
And added docevents in the hooks.py.
Also added Permission to Alumni and Student to access member doctype and address,contact and program doctypes.

## Output screenshots
![image](https://github.com/efeone/fosa_connect/assets/84098652/3b978008-7b0f-46f1-bc21-7ff252bed8c8)
Notification:
[Screencast from 15-09-23 03:32:14 PM IST.webm](https://github.com/efeone/fosa_connect/assets/84098652/4160d62e-0349-4141-b4c6-7fb9b536c8ec)
webview:
![image](https://github.com/efeone/fosa_connect/assets/84098652/4f4dc8cb-59b8-41ab-948b-6df2e2b17706)


## Areas affected and ensured
job_interest.py, hooks.py and member.json

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome
