### PR TITLE
Workflow

### DIFF
--- a/fosa_connect/fixtures/workflow.json
+++ b/fosa_connect/fixtures/workflow.json
@@ -1,0 +1,149 @@
+[
+ {
+  "docstatus": 0,
+  "doctype": "Workflow",
+  "document_type": "Job Interest",
+  "is_active": 1,
+  "modified": "2023-09-15 17:30:29.368728",
+  "name": "job interest status",
+  "override_status": 0,
+  "send_email_alert": 0,
+  "states": [
+   {
+    "allow_edit": "Student",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "job interest status",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Open",
+    "update_field": "status",
+    "update_value": ""
+   },
+   {
+    "allow_edit": "Alumni",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "job interest status",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Accepted",
+    "update_field": "status",
+    "update_value": "Accepted"
+   },
+   {
+    "allow_edit": "Alumni",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "job interest status",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "On Hold",
+    "update_field": "status",
+    "update_value": "On Hold"
+   },
+   {
+    "allow_edit": "Alumni",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "job interest status",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Rejected",
+    "update_field": "status",
+    "update_value": "Rejected"
+   },
+   {
+    "allow_edit": "Student",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "job interest status",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Cancelled",
+    "update_field": "status",
+    "update_value": "Cancelled"
+   }
+  ],
+  "transitions": [
+   {
+    "action": "Cancel",
+    "allow_self_approval": 1,
+    "allowed": "Student",
+    "condition": null,
+    "next_state": "Cancelled",
+    "parent": "job interest status",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Open"
+   },
+   {
+    "action": "Approve",
+    "allow_self_approval": 1,
+    "allowed": "Alumni",
+    "condition": null,
+    "next_state": "Accepted",
+    "parent": "job interest status",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Open"
+   },
+   {
+    "action": "Reject",
+    "allow_self_approval": 1,
+    "allowed": "Alumni",
+    "condition": null,
+    "next_state": "Rejected",
+    "parent": "job interest status",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Open"
+   },
+   {
+    "action": "Hold",
+    "allow_self_approval": 1,
+    "allowed": "Alumni",
+    "condition": null,
+    "next_state": "On Hold",
+    "parent": "job interest status",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Open"
+   },
+   {
+    "action": "Approve",
+    "allow_self_approval": 1,
+    "allowed": "Alumni",
+    "condition": null,
+    "next_state": "Accepted",
+    "parent": "job interest status",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "On Hold"
+   },
+   {
+    "action": "Reject",
+    "allow_self_approval": 1,
+    "allowed": "Alumni",
+    "condition": null,
+    "next_state": "Rejected",
+    "parent": "job interest status",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "On Hold"
+   }
+  ],
+  "workflow_name": "job interest status",
+  "workflow_state_field": "workflow_state"
+ }
+]

--- a/fosa_connect/fosa_connect/doctype/job_interest/job_interest.json
+++ b/fosa_connect/fosa_connect/doctype/job_interest/job_interest.json
@@ -29,7 +29,8 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Open\nAccepted\nRejected\nOn Hold\nCancelled"
+   "options": "Open\nAccepted\nRejected\nOn Hold\nCancelled",
+   "read_only": 1
   },
   {
    "fieldname": "posting_date",
@@ -59,7 +60,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2023-09-13 15:09:45.063766",
+ "modified": "2023-09-18 09:32:49.494136",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Job Interest",

--- a/fosa_connect/fosa_connect/doctype/job_interest/job_interest.json
+++ b/fosa_connect/fosa_connect/doctype/job_interest/job_interest.json
@@ -59,7 +59,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2023-09-07 17:05:16.733794",
+ "modified": "2023-09-13 15:09:45.063766",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Job Interest",
@@ -102,7 +102,7 @@
   }
  ],
  "quick_entry": 1,
- "route": "job",
+ "route": "job-interest",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
+++ b/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
@@ -10,32 +10,21 @@ from fosa_connect.fosa_connect.utils import create_notification_log
 class JobInterest(WebsiteGenerator):
     pass
 
-
-class JobInterest(Document):
-    def after_insert(self):
-        if self.job:
-            recipient = frappe.db.get_value("Job", self.job, "owner")
-            job_title = frappe.db.get_value("Job", self.job, "job_title")
-            job_create_notification_log(self, recipient, job_title)
-
-    def on_update(self):
-        if self.status != "Open":
-            recipient = frappe.db.get_value("Member", self.member, "email_id")
-            job_title = frappe.db.get_value("Job", self.job, "job_title")
-            student_notification_log(self, recipient, job_title, self.status)
-
-
 # Job Update for alumni
 @frappe.whitelist()
-def job_create_notification_log(doc, recipient, job_title):
-    subject = "New Job Interest for " + job_title
-    create_notification_log(doc, recipient, subject)
-    frappe.db.commit()
+def job_create_notification_log(doc, method=None):
+    if doc.job:
+        recipient = frappe.db.get_value("Job", doc.job, "owner")
+        job_title = frappe.db.get_value("Job", doc.job, "job_title")
+        subject = "New Job Interest for " + job_title
+        create_notification_log(doc, recipient, subject)
 
 
 # Job Update for student
 @frappe.whitelist()
-def student_notification_log(doc, recipient, job_title, status):
-    subject = "Job Interest update for " + job_title + " : " + status
-    create_notification_log(doc, recipient, subject)
-    frappe.db.commit()
+def student_notification_log(doc, method=None):
+    if doc.status != "Open":
+        recipient = frappe.db.get_value("Member", doc.member, "email_id")
+        job_title = frappe.db.get_value("Job", doc.job, "job_title")
+        subject = "Job Interest update for " + job_title + " : " + doc.status
+        create_notification_log(doc, recipient, subject)

--- a/fosa_connect/fosa_connect/doctype/member/member.json
+++ b/fosa_connect/fosa_connect/doctype/member/member.json
@@ -267,7 +267,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-05 13:07:17.956625",
+ "modified": "2023-09-13 15:21:02.523468",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Member",
@@ -283,6 +283,30 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Student",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Alumni",
    "share": 1,
    "write": 1
   }

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -120,13 +120,12 @@ signup_form_template = "fosa_connect/templates/signup.html"
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-#	"*": {
-#		"on_update": "method",
-#		"on_cancel": "method",
-#		"on_trash": "method"
-#	}
-# }
+doc_events = {
+    "Job Interest": {
+        "after_insert": "fosa_connect.fosa_connect.doctype.job_interest.job_interest.job_create_notification_log",
+        "on_update": "fosa_connect.fosa_connect.doctype.job_interest.job_interest.student_notification_log"
+    }
+}
 
 # Scheduled Tasks
 # ---------------

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -218,5 +218,5 @@ doc_events = {
 # ]
 
 fixtures = [
-    "Program", "Job Category"
+    "Program", "Job Category", "Workflow"
 ]


### PR DESCRIPTION
## Feature description
Created workflow for job interest.

## Solution description
Created workflow for job interest containing the states:
Open
Hold
Accepted
Rejected
Cancelled
Once a job interest is created, it will be in 'Open' state, student can cancel the Job Interest as well. The rest of the states are available to the Alumni user.
Added workflow as fixtures.
Changed the permission of status to read only.

## Output screenshots
[Screencast from 18-09-23 09:59:47 AM IST.webm](https://github.com/efeone/fosa_connect/assets/84098652/1be29b4b-abff-4993-8c2d-08fa38927c30)


## Areas affected and ensured
Hooks.py is affected and ensured. Added workflow to fixtures. Also job_interest.json is affected and ensured.
Other modified files are for the fix:Code error in the job_interest.py file of Job Interest doctype

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome