### PR TITLE
Email notification

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
+++ b/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
@@ -17,7 +17,8 @@ def job_create_notification_log(doc, method=None):
         recipient = frappe.db.get_value("Job", doc.job, "owner")
         job_title = frappe.db.get_value("Job", doc.job, "job_title")
         subject = "New Job Interest for " + job_title
-        create_notification_log(doc, recipient, subject)
+        content = "This is a sample email content"
+        create_notification_log(doc, recipient, subject, content)
 
 
 # Job Update for student
@@ -27,4 +28,5 @@ def student_notification_log(doc, method=None):
         recipient = frappe.db.get_value("Member", doc.member, "email_id")
         job_title = frappe.db.get_value("Job", doc.job, "job_title")
         subject = "Job Interest update for " + job_title + " : " + doc.status
-        create_notification_log(doc, recipient, subject)
+        content = "This is a sample email content"
+        create_notification_log(doc, recipient, subject, content)

--- a/fosa_connect/fosa_connect/utils.py
+++ b/fosa_connect/fosa_connect/utils.py
@@ -36,7 +36,7 @@ def create_notification_log(doc, recipient, subject, content=None, type=None):
         subject: subject of notification log
         type: type of the notification log"""
     notification_log = frappe.new_doc("Notification Log")
-    notification_log.type = "Alert"
+    notification_log.type = "Mention"
     if type:
         notification_log.type = type
     notification_log.document_type = doc.doctype


### PR DESCRIPTION
## Feature description
Added email notifications
Set default notification type to Mention in notification function

## Solution description
Added email notifications so that both alumni and students would get email notifications for job interest updates along with system notification.
Changed default notification type to Mention so that all notification log entry would trigger email notifications as well unless the notification type is explicitly stated.

## Output screenshots

**Email Notification for alumni who posted the job's when students apply**
![image](https://github.com/efeone/fosa_connect/assets/59536246/5eddcdb6-24df-497a-bb62-c32d96997b85)

**Email Notification for students on applied job status update**
![image](https://github.com/efeone/fosa_connect/assets/59536246/8d13cc32-5d4c-4b3a-ab8d-09a56d59c087)


## Areas affected and ensured
Notification to user.

## Is there any existing behavior change of other features due to this code change?
Yes. Before notifications were only sent as system notifications. Now email notifications would be sent as well.
 
## Was this feature tested on the browsers?
  - Mozilla Firefox
 