### PR TITLE
Email notification template added

### DIFF
--- a/fosa_connect/fixtures/email_template.json
+++ b/fosa_connect/fixtures/email_template.json
@@ -1,0 +1,22 @@
+[
+ {
+  "docstatus": 0,
+  "doctype": "Email Template",
+  "modified": "2023-09-28 10:35:11.696353",
+  "name": "Alumni - Received Job Application",
+  "response": null,
+  "response_html": "{% set job_details = frappe.get_doc(\"Job\", job) %}\n{% set alumni = frappe.get_doc(\"Member\", {'email_id':job_details.owner}) %}\n{% set student = frappe.get_doc(\"Member\", member) %}\n<p>Dear {{ alumni.first_name }},</p>\n\n<p>We are excited to inform you that a new job application has been received for the position of {{ job_details.job_title }} at your organization.</p>\n\n<p><strong>Applicant Details:</strong></p>\n<ul>\n    <li><strong>Name:</strong> {{ student.first_name }} {% if student.last_name %}{{ student.last_name }}{% endif %}</li>\n    <li><strong>Email:</strong> {{ student.email_id }}</li>\n</ul>\n\n<p>Please review the applicant's details and consider scheduling an interview or taking the appropriate next steps in your hiring process.</p>\n\n<p>If you have any questions or need further assistance, please don't hesitate to contact us.</p>\n\n<p>Best regards,</p>\n<p>Team FosaConnect</p>",
+  "subject": "New Job Interest for {{job}}",
+  "use_html": 1
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Email Template",
+  "modified": "2023-09-28 10:39:24.304989",
+  "name": "Student - Job Application Update",
+  "response": null,
+  "response_html": "{% set job_details = frappe.get_doc(\"Job\", job) %}\n{% set student = frappe.get_doc(\"Member\", member) %}\n<p>Hello {{ student.first_name }},</p>\n\n<p>We want to inform you about the status of your job application for the position \"{{ job_details.job_title }}\"</p>\n\n<p><strong>Status: {{ status }}</strong></p>\n\n{% if status == 'Accepted' %}\n<p>Congratulations! Your application has been accepted. You will be contacted shortly with further details.</p>\n{% elif status == 'Rejected' %}\n<p>We regret to inform you that your application has been rejected. Keep applying for other opportunities.</p>\n{% elif status == 'On Hold' %}\n<p>Your application has been placed on hold. We will contact you with updates when the status changes.</p>\n{% endif %}\n\n<p>Thank you for using our platform.</p>\n\n<p>Best regards,<br>\nTeam FosaConnect</p>\n</body>",
+  "subject": "Update on job application {{ job }}",
+  "use_html": 1
+ }
+]

--- a/fosa_connect/fixtures/workflow_state.json
+++ b/fosa_connect/fixtures/workflow_state.json
@@ -1,0 +1,65 @@
+[
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "question-sign",
+  "modified": "2023-09-01 10:15:28.349874",
+  "name": "Pending",
+  "style": "",
+  "workflow_state_name": "Pending"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "ok-sign",
+  "modified": "2023-09-01 10:15:28.353213",
+  "name": "Approved",
+  "style": "Success",
+  "workflow_state_name": "Approved"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "remove",
+  "modified": "2023-09-01 10:15:28.355917",
+  "name": "Rejected",
+  "style": "Danger",
+  "workflow_state_name": "Rejected"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2023-09-27 16:32:51.121990",
+  "name": "Open",
+  "style": "Primary",
+  "workflow_state_name": "Open"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2023-09-27 16:33:05.480558",
+  "name": "Accepted",
+  "style": "Success",
+  "workflow_state_name": "Accepted"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2023-09-27 16:33:17.618234",
+  "name": "On Hold",
+  "style": "Warning",
+  "workflow_state_name": "On Hold"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2023-09-28 09:30:52.247526",
+  "name": "Cancelled",
+  "style": "Inverse",
+  "workflow_state_name": "Cancelled"
+ }
+]

--- a/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
+++ b/fosa_connect/fosa_connect/doctype/job_interest/job_interest.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 from frappe.model.document import Document
+from frappe.email.doctype.email_template.email_template import get_email_template
 from fosa_connect.fosa_connect.utils import create_notification_log
 
 
@@ -17,7 +18,8 @@ def job_create_notification_log(doc, method=None):
         recipient = frappe.db.get_value("Job", doc.job, "owner")
         job_title = frappe.db.get_value("Job", doc.job, "job_title")
         subject = "New Job Interest for " + job_title
-        content = "This is a sample email content"
+        email_template = get_email_template("Alumni - Received Job Application", doc.as_dict())
+        content = email_template['message']
         create_notification_log(doc, recipient, subject, content)
 
 
@@ -28,5 +30,6 @@ def student_notification_log(doc, method=None):
         recipient = frappe.db.get_value("Member", doc.member, "email_id")
         job_title = frappe.db.get_value("Job", doc.job, "job_title")
         subject = "Job Interest update for " + job_title + " : " + doc.status
-        content = "This is a sample email content"
+        email_template = get_email_template("Student - Job Application Update", doc.as_dict())
+        content = email_template['message']
         create_notification_log(doc, recipient, subject, content)

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -218,5 +218,5 @@ doc_events = {
 # ]
 
 fixtures = [
-    "Program", "Job Category", "Workflow", "Email Template"
+    "Program", "Job Category", "Workflow", "Workflow State", "Email Template"
 ]

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -218,5 +218,5 @@ doc_events = {
 # ]
 
 fixtures = [
-    "Program", "Job Category", "Workflow"
+    "Program", "Job Category", "Workflow", "Email Template"
 ]


### PR DESCRIPTION
## Feature description
Added template for email notification
Added fixture for workflow state

## Solution description
Added email template feature for the email notification send to users. Now we can change the template of the email by adding the document in Email Template DocType and changing arguements of get_email_template function.

## Output screenshots
**Alumni Email Sample**

![image](https://github.com/efeone/fosa_connect/assets/59536246/c1310320-c405-41a5-aea3-c451fedbf15d)

**Student Email Sample**

![image](https://github.com/efeone/fosa_connect/assets/59536246/0c9dc337-0a6e-4c72-8d21-b6bac624e4e5)


## Areas affected and ensured
Email Notification

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
 - Mozilla Firefox