### PR TITLE
Fix jobpost

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job/job.json
+++ b/fosa_connect/fosa_connect/doctype/job/job.json
@@ -21,7 +21,8 @@
   "location",
   "job_type",
   "last_date_to_apply",
-  "salary_info"
+  "salary_info",
+  "organization_name"
  ],
  "fields": [
   {
@@ -87,7 +88,7 @@
    "fieldname": "job_type",
    "fieldtype": "Select",
    "label": "Job Type",
-   "options": "Full\nPart"
+   "options": "Full Time\nPart Time"
   },
   {
    "default": "0",
@@ -109,10 +110,15 @@
    "label": "Is Published",
    "permlevel": 1,
    "read_only_depends_on": "eval:doc.disabled"
+  },
+  {
+   "fieldname": "organization_name",
+   "fieldtype": "Data",
+   "label": "Organization Name"
   }
  ],
  "links": [],
- "modified": "2023-10-03 16:22:21.278396",
+ "modified": "2023-10-06 15:26:16.236228",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Job",

--- a/fosa_connect/www/jobs/job.html
+++ b/fosa_connect/www/jobs/job.html
@@ -17,7 +17,11 @@
           <h1 style="color: black; flex: 1; margin: auto;margin-bottom: 20px;">{{ jobs.job_title }}</h1>
           <div class="apply-button">
              {%- if "Alumni" not in context.roles -%}
+              {%- if frappe.db.exists("Job Interest", {"job": jobs.name, "member": member}) -%}
+             <label style="color: green;">&#10003; Applied</label>
+             {%- else -%}
              <button class="btn" id="interestButton" onclick="create_job_interest()">Apply Now</button>
+             {%- endif -%}
             {%- else -%}
               <button class="btn" id="interestButton" onclick="toggleInterest()">Edit Here</button>
               {%- endif -%}
@@ -46,6 +50,7 @@
     </div>
     <hr>
     <p style="text-align: justify;"><i class="fas fa-file-alt"></i> {{ jobs.job_description }}</p>
+    <p><span style="font-weight: bold;">Published by: {{owner}}, {{jobs.organization_name}}</span></p>
   </div>
 </div>
 <style>
@@ -88,6 +93,9 @@ function create_job_interest() {
       job_id: "{{ jobs.name }}",
       student_id: frappe.session.user,
     },
+    callback: function(response) {
+      location.reload();
+    }
   });
 }
 </script>

--- a/fosa_connect/www/jobs/job.py
+++ b/fosa_connect/www/jobs/job.py
@@ -3,7 +3,9 @@ import frappe
 
 def get_context(context):
     context.roles = frappe.get_roles(frappe.session.user)
+    context.member = frappe.get_value("Member", {"email_id": frappe.session.user}, "name")
     context.jobs = frappe.get_doc('Job',frappe.form_dict.docname)
+    context.owner = frappe.get_value("Member", {"email_id": context.jobs.owner}, "first_name")
     return {
         "context": context
     }


### PR DESCRIPTION
## Feature description
Add Organization name field in job doctype.
the student can view alumni name and organization name in job details.
when student user  click apply now button it automatically  changed into applied.


## Solution description
Add code in job.html and job.py for when click apply now button it automatically  changed into applied.
add new field organization name in job doctype.

## Output screenshots (optional)
[Screencast from 06-10-23 05:30:09 PM IST.webm](https://github.com/efeone/fosa_connect/assets/84180042/94757024-8f57-4833-9e80-5657cae4523e)



## Areas affected and ensured
web page

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?

  - Mozilla Firefox

