### PR TITLE
feat:Add functions to set default landing page and disable signup

### DIFF
--- a/fosa_connect/fosa_connect/utils.py
+++ b/fosa_connect/fosa_connect/utils.py
@@ -46,3 +46,14 @@ def create_notification_log(doc, recipient, subject, content=None, type=None):
     if content:
         notification_log.email_content = content
     notification_log.save(ignore_permissions=True)
+
+def set_uncheck_disable_signup():
+    website_settings = frappe.get_single("Website Settings")
+    if website_settings.disable_signup:
+        website_settings.disable_signup = 0
+        website_settings.save()
+
+def set_default_landing_page():
+    website_settings = frappe.get_single("Website Settings")
+    website_settings.home_page = "home"
+    website_settings.save()

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -64,7 +64,8 @@ app_license = "MIT"
 # ------------
 
 # before_install = "fosa_connect.install.before_install"
-# after_install = "fosa_connect.install.after_install"
+after_install = "fosa_connect.fosa_connect.utils.set_uncheck_disable_signup"
+after_install = "fosa_connect.fosa_connect.utils.set_default_landing_page"
 
 # Uninstallation
 # ------------


### PR DESCRIPTION
## Feature description
Add functions to set default landing page and uncheck disable_signup after install the app.

## Solution description
Add function to set default landing page and uncheck disable_signup in utils.py and add script to call the function when in hooks.py

## Output screenshots 
utils.py:
![image](https://github.com/efeone/fosa_connect/assets/84098652/681f2d08-d399-43b7-9f89-30d1b8c614fe)

hooks.py:
![image](https://github.com/efeone/fosa_connect/assets/84098652/fe1a478a-2bbd-480e-89e5-25e6caa20547)

## Areas affected and ensured
utils.py and hooks.py is affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
