### PR TITLE
feat: workflow for signup

### DIFF
--- a/fosa_connect/fixtures/workflow.json
+++ b/fosa_connect/fixtures/workflow.json
@@ -2,6 +2,94 @@
  {
   "docstatus": 0,
   "doctype": "Workflow",
+  "document_type": "User",
+  "is_active": 1,
+  "modified": "2023-10-13 11:24:14.238803",
+  "name": "User Approval",
+  "override_status": 1,
+  "send_email_alert": 1,
+  "states": [
+   {
+    "allow_edit": "Guest",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "User Approval",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Pending",
+    "update_field": "enabled",
+    "update_value": "0"
+   },
+   {
+    "allow_edit": "Placement Officer",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "User Approval",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Enabled",
+    "update_field": "enabled",
+    "update_value": "1"
+   },
+   {
+    "allow_edit": "Placement Officer",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "User Approval",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Disabled",
+    "update_field": "enabled",
+    "update_value": "0"
+   }
+  ],
+  "transitions": [
+   {
+    "action": "Approve",
+    "allow_self_approval": 1,
+    "allowed": "Placement Officer",
+    "condition": null,
+    "next_state": "Enabled",
+    "parent": "User Approval",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Pending"
+   },
+   {
+    "action": "Reject",
+    "allow_self_approval": 1,
+    "allowed": "Placement Officer",
+    "condition": null,
+    "next_state": "Enabled",
+    "parent": "User Approval",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Pending"
+   },
+   {
+    "action": "Disabled",
+    "allow_self_approval": 1,
+    "allowed": "Placement Officer",
+    "condition": null,
+    "next_state": "Disabled",
+    "parent": "User Approval",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Enabled"
+   }
+  ],
+  "workflow_name": "User Approval",
+  "workflow_state_field": "workflow_state"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow",
   "document_type": "Job Interest",
   "is_active": 1,
   "modified": "2023-09-15 17:30:29.368728",

--- a/fosa_connect/fixtures/workflow_state.json
+++ b/fosa_connect/fixtures/workflow_state.json
@@ -2,6 +2,15 @@
  {
   "docstatus": 0,
   "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2023-10-07 16:29:19.920227",
+  "name": "Enabled",
+  "style": "",
+  "workflow_state_name": "Enabled"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
   "icon": "question-sign",
   "modified": "2023-09-01 10:15:28.349874",
   "name": "Pending",
@@ -61,5 +70,14 @@
   "name": "Cancelled",
   "style": "Inverse",
   "workflow_state_name": "Cancelled"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2023-10-07 16:29:38.116967",
+  "name": "Disabled",
+  "style": "",
+  "workflow_state_name": "Disabled"
  }
 ]

--- a/fosa_connect/fosa_connect/utils.py
+++ b/fosa_connect/fosa_connect/utils.py
@@ -57,3 +57,17 @@ def set_default_landing_page():
     website_settings = frappe.get_single("Website Settings")
     website_settings.home_page = "home"
     website_settings.save()
+
+@frappe.whitelist()
+def user_validate(doc, method=None):
+    if doc.email:
+        member_type = frappe.get_value("Member", {"email_id": doc.email}, "member_type")
+        print("member_type :", member_type)
+        if doc.workflow_state == "Enabled" and member_type == "Student":
+            print("in if")
+            row = doc.append('roles')
+            row.role = 'Student'
+        if doc.workflow_state == "Enabled" and member_type == "Alumni":
+            print("in else")
+            row = doc.append('roles')
+            row.role = 'Alumni'

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -64,8 +64,7 @@ app_license = "MIT"
 # ------------
 
 # before_install = "fosa_connect.install.before_install"
-after_install = "fosa_connect.fosa_connect.utils.set_uncheck_disable_signup"
-after_install = "fosa_connect.fosa_connect.utils.set_default_landing_page"
+# after_install = "fosa_connect.install.after_install"
 
 # Uninstallation
 # ------------
@@ -125,7 +124,10 @@ doc_events = {
     "Job Interest": {
         "after_insert": "fosa_connect.fosa_connect.doctype.job_interest.job_interest.job_create_notification_log",
         "on_update": "fosa_connect.fosa_connect.doctype.job_interest.job_interest.student_notification_log"
-    }
+    },
+	"User": {
+	   "validate": "fosa_connect.fosa_connect.utils.user_validate"
+	   }
 }
 
 # Scheduled Tasks

--- a/fosa_connect/www/home/index.html
+++ b/fosa_connect/www/home/index.html
@@ -36,9 +36,9 @@
         <link rel="icon" href="home/images/favicon.webp" type="image/x-icon">
     </head>
     <body>
-        
+
         <div>
-            
+
             <div class="home-container">
                 <div class="home-head">
                     <nav class="navbar-navbar">
@@ -79,17 +79,17 @@
                             </div>
                             <div class="navbar-quick-actions">
                                 {% if frappe.session.user == "Guest" %}
-                                <a href="http://127.0.0.1:8000/login">
+                                <a href="/login">
                                     <div class="navbar-sign-up-btn">
                                         <span class="navbar-sign-up">Sign in</span>
                                     </div>
                                 </a>
                                 {% else %}
-                                
+
                                     <div class="navbar-sign-up-btn" onclick="logoutUser()">
                                         <span class="navbar-sign-up">Logout</span>
                                     </div>
-                                
+
                                 {% endif %}
                                 <img
                                     id="open-mobile-menu"


### PR DESCRIPTION
## Feature description
When a user signs up, they are initially in a disabled state. Once the administrator approves the user, the user is enabled, and a welcome email is sent to them.

## Solution description
Users initially sign up with disabled accounts, administrators review and enable these accounts, and an automated welcome email is sent upon approval. This enhances user onboarding and simplifies administrative approval processes.

## Output screenshots (optional)
[Screencast from 16-10-23 12:55:57 PM IST.webm](https://github.com/efeone/fosa_connect/assets/84180042/3c2e1ccd-4615-42e9-9be1-43bf90e9d57a)


## Areas affected and ensured
User Onboarding. 

## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?

  - Mozilla Firefox
 
