### PR TITLE
feat: workflow for signup

### DIFF
--- a/fosa_connect/fixtures/workflow.json
+++ b/fosa_connect/fixtures/workflow.json
@@ -2,6 +2,94 @@
  {
   "docstatus": 0,
   "doctype": "Workflow",
+  "document_type": "User",
+  "is_active": 1,
+  "modified": "2023-10-13 11:24:14.238803",
+  "name": "User Approval",
+  "override_status": 1,
+  "send_email_alert": 1,
+  "states": [
+   {
+    "allow_edit": "Guest",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "User Approval",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Pending",
+    "update_field": "enabled",
+    "update_value": "0"
+   },
+   {
+    "allow_edit": "Placement Officer",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "User Approval",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Enabled",
+    "update_field": "enabled",
+    "update_value": "1"
+   },
+   {
+    "allow_edit": "Placement Officer",
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "User Approval",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Disabled",
+    "update_field": "enabled",
+    "update_value": "0"
+   }
+  ],
+  "transitions": [
+   {
+    "action": "Approve",
+    "allow_self_approval": 1,
+    "allowed": "Placement Officer",
+    "condition": null,
+    "next_state": "Enabled",
+    "parent": "User Approval",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Pending"
+   },
+   {
+    "action": "Reject",
+    "allow_self_approval": 1,
+    "allowed": "Placement Officer",
+    "condition": null,
+    "next_state": "Enabled",
+    "parent": "User Approval",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Pending"
+   },
+   {
+    "action": "Disabled",
+    "allow_self_approval": 1,
+    "allowed": "Placement Officer",
+    "condition": null,
+    "next_state": "Disabled",
+    "parent": "User Approval",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Enabled"
+   }
+  ],
+  "workflow_name": "User Approval",
+  "workflow_state_field": "workflow_state"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow",
   "document_type": "Job Interest",
   "is_active": 1,
   "modified": "2023-09-15 17:30:29.368728",

--- a/fosa_connect/fixtures/workflow_state.json
+++ b/fosa_connect/fixtures/workflow_state.json
@@ -2,6 +2,15 @@
  {
   "docstatus": 0,
   "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2023-10-07 16:29:19.920227",
+  "name": "Enabled",
+  "style": "",
+  "workflow_state_name": "Enabled"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
   "icon": "question-sign",
   "modified": "2023-09-01 10:15:28.349874",
   "name": "Pending",
@@ -61,5 +70,14 @@
   "name": "Cancelled",
   "style": "Inverse",
   "workflow_state_name": "Cancelled"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2023-10-07 16:29:38.116967",
+  "name": "Disabled",
+  "style": "",
+  "workflow_state_name": "Disabled"
  }
 ]

--- a/fosa_connect/fosa_connect/overrides.py
+++ b/fosa_connect/fosa_connect/overrides.py
@@ -26,20 +26,16 @@ def sign_up(email, first_name, last_name, full_name,  member_type, admission_num
         "last_name": escape_html(last_name),
         "full_name": escape_html(full_name),
         "country": "",
-        "enabled": 1,
+        "enabled": 0,
         "new_password": random_string(10),
         "user_type": "Website User",
         "send_welcome_email": 0
     })
     user.flags.ignore_permissions = True
     user.flags.ignore_password_policy = True
-    user.insert()
-# set default signup role as per Portal Settings
-    default_role = frappe.db.get_value("Portal Settings", None, "default_role")
-    if default_role:
-        user.add_roles(default_role)
+    user.insert(ignore_permissions=True)
 
-    # Create a member record
+
     create_member(email, first_name, last_name, member_type,admission_number, year_of_admission, department, year_of_passing, job_title, designation)
 
     if user.flags.email_sent:
@@ -50,21 +46,8 @@ def sign_up(email, first_name, last_name, full_name,  member_type, admission_num
 
 @frappe.whitelist(allow_guest=True)
 def create_member(email, first_name, last_name, member_type, admission_number=None, year_of_admission=None, department=None, year_of_passing=None, job_title=None, designation=None):
-    # Check if a member with the same admission number already exists
-    existing_member = frappe.get_all("Member", filters={"admission_number": admission_number}, limit=1)
-
-    if existing_member:
-        # Member with the same admission number exists
-        existing_member_doc = frappe.get_doc("Member", existing_member[0]["name"])
-
-        # You can choose to update the existing member's information here if needed
-        # Example: existing_member_doc.first_name = first_name
-        # Update other fields as necessary
-
-        existing_member_doc.save()
-        frappe.db.commit()
-
-        return existing_member_doc.name  # Return the name of the existing member
+    if frappe.db.exists('Member', { 'email': email }):
+        frappe.throw('Member already registered with this email id.')
     else:
         # Create a new member
         member_data = {
@@ -84,7 +67,7 @@ def create_member(email, first_name, last_name, member_type, admission_number=No
         member = frappe.get_doc(member_data)
         member.flags.ignore_permissions = True
         member.flags.ignore_password_policy = True
-        member.insert()
+        member.insert(ignore_permissions=True)
         frappe.db.commit()
 
         return member.name  # Return the name of the newly created member

--- a/fosa_connect/fosa_connect/utils.py
+++ b/fosa_connect/fosa_connect/utils.py
@@ -57,3 +57,18 @@ def set_default_landing_page():
     website_settings = frappe.get_single("Website Settings")
     website_settings.home_page = "home"
     website_settings.save()
+    
+#assign role to user after approval
+@frappe.whitelist()
+def user_validate(doc, method=None):
+    if doc.email:
+        member_type = frappe.get_value("Member", {"email_id": doc.email}, "member_type")
+        print("member_type :", member_type)
+        if doc.workflow_state == "Enabled" and member_type == "Student":
+            print("in if")
+            row = doc.append('roles')
+            row.role = 'Student'
+        if doc.workflow_state == "Enabled" and member_type == "Alumni":
+            print("in else")
+            row = doc.append('roles')
+            row.role = 'Alumni'

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -64,8 +64,7 @@ app_license = "MIT"
 # ------------
 
 # before_install = "fosa_connect.install.before_install"
-after_install = "fosa_connect.fosa_connect.utils.set_uncheck_disable_signup"
-after_install = "fosa_connect.fosa_connect.utils.set_default_landing_page"
+# after_install = "fosa_connect.install.after_install"
 
 # Uninstallation
 # ------------
@@ -125,7 +124,10 @@ doc_events = {
     "Job Interest": {
         "after_insert": "fosa_connect.fosa_connect.doctype.job_interest.job_interest.job_create_notification_log",
         "on_update": "fosa_connect.fosa_connect.doctype.job_interest.job_interest.student_notification_log"
-    }
+    },
+	"User": {
+	   "validate": "fosa_connect.fosa_connect.utils.user_validate"
+	   }
 }
 
 # Scheduled Tasks

--- a/fosa_connect/www/home/index.html
+++ b/fosa_connect/www/home/index.html
@@ -36,9 +36,9 @@
         <link rel="icon" href="home/images/favicon.webp" type="image/x-icon">
     </head>
     <body>
-        
+
         <div>
-            
+
             <div class="home-container">
                 <div class="home-head">
                     <nav class="navbar-navbar">
@@ -79,17 +79,17 @@
                             </div>
                             <div class="navbar-quick-actions">
                                 {% if frappe.session.user == "Guest" %}
-                                <a href="http://127.0.0.1:8000/login">
+                                <a href="/login">
                                     <div class="navbar-sign-up-btn">
                                         <span class="navbar-sign-up">Sign in</span>
                                     </div>
                                 </a>
                                 {% else %}
-                                
+
                                     <div class="navbar-sign-up-btn" onclick="logoutUser()">
                                         <span class="navbar-sign-up">Logout</span>
                                     </div>
-                                
+
                                 {% endif %}
                                 <img
                                     id="open-mobile-menu"


### PR DESCRIPTION
## Feature description
When a user signs up, they are initially in a disabled state. Once the administrator approves the user, the user is enabled, and a welcome email is sent to them.

## Solution description
Users initially sign up with disabled accounts, administrators review and enable these accounts, and an automated welcome email is sent upon approval. This enhances user onboarding and simplifies administrative approval processes.

## Output screenshots (optional)
[Screencast from 16-10-23 12:55:57 PM IST.webm](https://github.com/efeone/fosa_connect/assets/84180042/a1a9852f-684b-43ae-904f-abfe4e7e23cd)


## Areas affected and ensured
 User onboarding

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?

  - Mozilla Firefox
