### PR TITLE
fix:send welcome mail to  user after approval

### DIFF
--- a/fosa_connect/fosa_connect/utils.py
+++ b/fosa_connect/fosa_connect/utils.py
@@ -57,18 +57,19 @@ def set_default_landing_page():
     website_settings = frappe.get_single("Website Settings")
     website_settings.home_page = "home"
     website_settings.save()
-    
+
 #assign role to user after approval
 @frappe.whitelist()
 def user_validate(doc, method=None):
     if doc.email:
         member_type = frappe.get_value("Member", {"email_id": doc.email}, "member_type")
-        print("member_type :", member_type)
-        if doc.workflow_state == "Enabled" and member_type == "Student":
-            print("in if")
-            row = doc.append('roles')
-            row.role = 'Student'
-        if doc.workflow_state == "Enabled" and member_type == "Alumni":
-            print("in else")
-            row = doc.append('roles')
-            row.role = 'Alumni'
+        if doc.workflow_state == "Enabled":
+            if member_type == "Student":
+                row = doc.append('roles')
+                row.role = 'Student'
+                doc.send_welcome_mail_to_user()
+        if doc.workflow_state == "Enabled":
+            if member_type == "Alumni":
+                row = doc.append('roles')
+                row.role = 'Alumni'
+                doc.send_welcome_mail_to_user()

--- a/fosa_connect/templates/signup_form.html
+++ b/fosa_connect/templates/signup_form.html
@@ -129,7 +129,7 @@
         </div>
     </div>
     <div class="page-card-actions">
-        <button class="btn btn-sm btn-primary btn-block btn-signup" type="submit">{{ _("Sign up") }}</button>
+        <button class="btn btn-sm btn-primary btn-block btn-signup" type="submit" id="signupBtn">{{ _("Sign up") }}</button>
         <p class="text-center sign-up-message">
             <a href="#login" class="blue">{{ _("Have an account? Login") }}</a>
         </p>
@@ -137,8 +137,8 @@
 </form>
 <script>
     frappe.ready(function () {
-        $(".signup-form-fosa").on("submit", (e) => {
-            signup_fosa_connect(e);
+        $("#signupBtn").click(function(e){
+          signup_fosa_connect(e);
         });
     });
 
@@ -162,6 +162,8 @@
 
           frappe.call({
               method: "fosa_connect.fosa_connect.overrides.sign_up",
+              freeze: true,
+              freeze_message: "Signing up. Please wait...",
               args: {
                   "email": email,
                   "first_name": first_name,


### PR DESCRIPTION
## Feature description
A user signs up, and upon approval by the placement officer, a welcome email is sent to the user's email address.

## Solution description
Add code in hooks.py  and signup.html

## Output screenshots (optional)
![Uploading Screenshot from 2023-11-15 16-25-21.png…]()


## Areas affected and ensured
Sign in 

## Is there any existing behavior change of other features due to this code change?
 No. 
## Was this feature tested on the browsers?
  
  - Mozilla Firefox
  
