### PR TITLE
chore:making signup link enable at first time itself for new member

### DIFF
--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -64,7 +64,7 @@ home_page = "home"
 # ------------
 
 # before_install = "fosa_connect.install.before_install"
-# after_install = "fosa_connect.install.after_install"
+after_install = "fosa_connect.fosa_connect.utils.set_uncheck_disable_signup"
 
 # Uninstallation
 # ------------


### PR DESCRIPTION
## Feature description
A member Can signup link at first time without unchecking disable by administrator



## Output screenshots (optional)
![Screenshot from 2023-11-24 20-28-06](https://github.com/efeone/fosa_connect/assets/133144039/83c04535-2ca6-41bc-af15-851b45f4ba32)



## Was this feature tested on the browsers?
  - Mozilla Firefox

