### PR TITLE
fix:add links to about us in navbar

### DIFF
--- a/fosa_connect/templates/base.html
+++ b/fosa_connect/templates/base.html
@@ -92,10 +92,27 @@
                 <span>Features</span>
             </a>
           </li>
-          <li>
-            <span class="nav-link">
-                <span>About Us</span>
-            </span>
+          <li class="nav-item dropdown logged-in">
+						<a href="#" class="nav-link" data-toggle="dropdown">
+        			<span>About Us</span>
+        		</a>
+						<ul class="dropdown-menu dropdown-menu-right" role="menu">
+							<a class="dropdown-item" href="https://farookcollege.ac.in/history" rel="nofollow">
+								History
+							</a>
+							<a class="dropdown-item" href="https://farookcollege.ac.in/vision-mission" rel="nofollow">
+								Vision & Mission
+							</a>
+							<a class="dropdown-item" href="https://farookcollege.ac.in/milestone" rel="nofollow">
+								Milestones
+							</a>
+							<a class="dropdown-item" href="https://farookcollege.ac.in/sister-institutions" rel="nofollow">
+								Sister Institutions
+							</a>
+							<a class="dropdown-item" href="https://farookcollege.ac.in/former-principals" rel="nofollow">
+								Former Leaders
+							</a>
+						</ul>
           </li>
 					<li class="nav-item dropdown logged-in">
             <a href="/members" class="nav-link">

--- a/fosa_connect/www/home/index.css
+++ b/fosa_connect/www/home/index.css
@@ -12,7 +12,7 @@
   justify-content: space-between;
 }
 .link span {
-       font-size: 16px; /* Adjust the size as needed */
+       font-size: 16px;
    }
 /* Style the dropdown container */
 .navbar-link1.dropdown {
@@ -36,6 +36,8 @@
 .navbar-link1 .dropdown-menu li {
     padding: 10px;
     list-style: none;
+    background-color: white;
+
 }
 
 /* Style the dropdown item links */
@@ -99,7 +101,7 @@
   gap: var(--dl-space-space-threeunits);
   width: 100%;
   display: flex;
-  font-size: 18px;
+  font-size: 15px;
   align-self: flex-start;
   align-items: flex-end;
   font-family: Poppins;

--- a/fosa_connect/www/home/index.html
+++ b/fosa_connect/www/home/index.html
@@ -65,7 +65,7 @@
                                     <div class="navbar-links">
                                       {% if not frappe.session.user == "Guest" %}
                                       <div class="navbar-link1 link dropdown">
-                                          <span class="dropdown-toggle" onclick="toggleDropdown()">Career</span>
+                                          <span class="dropdown-toggle" onclick="toggleDropdown(this.parentElement)">Career</span>
                                           <ul class="dropdown-menu">
                                               <li><a href="/jobs">Jobs</a></li>
                                               <li><a href="/job_interest">Interested Jobs</a></li>
@@ -82,9 +82,18 @@
                                         <a href="#slideshow" class="navbar-link00 link">
                                             <span>SlideShow</span>
                                         </a>
-                                        <a href="/about" class="link">
-                                            <span>About Us</span>
-                                        </a>
+                                        <div class="navbar-link1 link dropdown">
+                                            <span class="dropdown-toggle" id="hww" onclick="toggleDropdown(this.parentElement)">About Us</span>
+                                            <ul class="dropdown-menu">
+                                                <li><a href="https://farookcollege.ac.in/history">History</a></li>
+                                                <li><a href="https://farookcollege.ac.in/vision-mission">Vision &Mission</a></li>
+                                                <li><a href="https://farookcollege.ac.in/milestone">Milestones</a></li>
+                                                <li><a href="https://farookcollege.ac.in/sister-institutions">Sister Institutions</a></li>
+                                                <li><a href="https://farookcollege.ac.in/former-principals">Former Leaders</a></li>
+
+                                            </ul>
+
+                                        </div>
                                         {% if not frappe.session.user == "Guest" %}
                                         <a href="/members" class="navbar-link2 link" style="margin-right: 10px;">
                                             <span>Profile</span>
@@ -159,7 +168,6 @@
                   /*
                   Mobile menu - Code Embed
                   */
-
                   // Mobile menu
                   const mobileMenu = document.querySelector('#mobile-menu');
 
@@ -470,11 +478,8 @@ var swiper = new Swiper(".slide-content", {
   });
 
 
-
-
-
-    function toggleDropdown() {
-      var dropdownMenu = document.querySelector('.navbar-link1 .dropdown-menu');
+    function toggleDropdown(item) {
+      var dropdownMenu = item.querySelector('.navbar-link1 .dropdown-menu');
       if (dropdownMenu.style.display === 'block') {
           dropdownMenu.style.display = 'none';
       } else {
@@ -494,4 +499,16 @@ var swiper = new Swiper(".slide-content", {
             console.error('Error logging out:', error);
         });
     }
+    document.addEventListener('click', function (event) {
+    // Check if the clicked element is inside the Career or About Us dropdowns or their parents
+    var careerDropdown = event.target.closest('.navbar-link1 .dropdown');
+    var aboutUsDropdown = event.target.closest('.navbar-link1.link.dropdown');
+
+    if (!careerDropdown && !aboutUsDropdown) {
+        // Clicked outside Career and About Us dropdowns, hide them
+        document.querySelectorAll('.navbar-link1 .dropdown-menu').forEach(function (dropdownMenu) {
+            dropdownMenu.style.display = 'none';
+        });
+    }
+});
 </script>


### PR DESCRIPTION
## Feature description
When clicking on 'About Us,' a drop-down appears with options such as history, vision & mission, etc. Subsequently, upon clicking on each option, users can view the corresponding information

## Solution description
Add Links on about us page.

## Output screenshots (optional)
[Screencast from 05-12-23 12:49:18 PM IST.webm](https://github.com/efeone/fosa_connect/assets/84180042/9562ddac-b3ab-476a-96be-ee647daab192)

## Areas affected and ensured
Home Page (Navbar)

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
  