### PR TITLE
feat: Added feature to upload job details file while posting jobs

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job/job.json
+++ b/fosa_connect/fosa_connect/doctype/job/job.json
@@ -15,6 +15,7 @@
   "responsibility",
   "start_date",
   "job_description",
+  "job_details",
   "column_break_lzsug",
   "disabled",
   "job_category",
@@ -115,10 +116,15 @@
    "fieldname": "organization_name",
    "fieldtype": "Data",
    "label": "Organization Name"
+  },
+  {
+   "fieldname": "job_details",
+   "fieldtype": "Attach",
+   "label": "Job Details"
   }
  ],
  "links": [],
- "modified": "2023-11-28 15:51:32.877994",
+ "modified": "2023-12-05 12:59:18.646065",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Job",

--- a/fosa_connect/fosa_connect/doctype/job/job.py
+++ b/fosa_connect/fosa_connect/doctype/job/job.py
@@ -54,5 +54,4 @@ def post_job(job_title, qualification, responsibility, start_date, end_date, job
     job_doc = frappe.get_doc(job_data)
     job_doc.insert()
     frappe.db.commit()
-
-    return "Job created successfully"
+    return job_doc.name

--- a/fosa_connect/www/post_job/index.css
+++ b/fosa_connect/www/post_job/index.css
@@ -34,6 +34,7 @@
       font-family: 'Merriweather', sans-serif;
       box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
       resize: none;
+      background-color: white;
     }
 
     input:focus, textarea:focus {

--- a/fosa_connect/www/post_job/index.html
+++ b/fosa_connect/www/post_job/index.html
@@ -6,7 +6,7 @@
 
 <body>
   <h1>Post Job</h1>
-  <form class="cf">
+  <form class="cf" id="post_job">
     <div class="half left cf">
       <input type="text" id="input-title" placeholder="Job Title">
       <select id="input-qualification">
@@ -45,10 +45,12 @@
       <textarea class="message" name="message" type="text" id="input-message" placeholder="Job Description"></textarea>
     </div>
     <div>
+      <input type="file" name="uploadPdf" id="uploadPdf">
+    </div>
+    <div>
       <label for="isPublished">Publish</label>
       <input type="checkbox" id="isPublished" name="isPublished" value="1" checked>
-  </div>
-
+    </div>
 
     <div class="button-container">
       <button class="discard" type="reset">Discard</button>

--- a/fosa_connect/www/post_job/index.js
+++ b/fosa_connect/www/post_job/index.js
@@ -1,13 +1,36 @@
 $(document).ready(function () {
-  console.log("on load");
-  $("#input-submit").click(function(){
-    console.log("Button clicked!");
+  $("#input-submit").click(function () {
     createJobEntry();
   });
+  var $form = $("form[id='post_job']")
+    $form.on("change", "[type='file']", function () {
+      var $input = $(this);
+      var input = $input.get(0);
+      if (input.files.length) {
+        input.filedata = { "files_data": [] }; //Initialize as json array.
+        window.file_reading = true;
+        $.each(input.files, function (key, value) {
+          setupReader(value, input);
+        });
+        window.file_reading = false;
+      }
+    });
+    function setupReader(file, input) {
+      var name = file.name;
+      var reader = new FileReader();
+      reader.onload = function (e) {
+        input.filedata.files_data.push({
+          "__file_attachment": 1,
+          "filename": file.name,
+          "dataurl": reader.result
+        });
+      };
+      reader.readAsDataURL(file);
+    }
 });
 
 const createJobEntry = () => {
-  if(document.getElementById('isPublished').checked){
+  if (document.getElementById('isPublished').checked) {
     var isPublished = 1;
   }
   else {
@@ -25,10 +48,11 @@ const createJobEntry = () => {
     let salary = $("#input-salary").val().trim() || '';
     let message = $("#input-message").val().trim() || '';
     let organization = $("#input-organization").val().trim() || '';
-
+    let docName;
     // Create a new job posting entry
     frappe.call({
         method: "fosa_connect.fosa_connect.doctype.job.job.post_job",
+        freeze: true,
         args: {
             "job_title": title,
             "qualification": qualification,
@@ -40,11 +64,31 @@ const createJobEntry = () => {
             "job_type": type,
             "salary_info": salary,
             "job_description": message,
-            "organization" : organization,
-            "isPublished" : isPublished
+            "organization": organization,
+            "isPublished": isPublished
         },
         callback: function (response) {
             if (response.message) {
+                docName = response.message;
+                var filedata = $('#uploadPdf').prop('filedata')
+                frappe.call({
+                    method: 'fosa_connect.www.post_job.index.upload_file',
+                    args: {
+                        'filedata': filedata,
+                        'doc_name': docName,
+                    },
+                    freeze: true,
+                    freeze_msg: 'Uploading',
+                    callback: function (r) {
+                        if (r.message) {
+                            alert('File uploaded successfully ');
+                            location.reload(true);
+                        } else {
+                            // Handle errors here
+                            alert('Error: ' + r.exc);
+                        }
+                    }
+                });
                 // Display a success message or redirect the user
                 alert("Job posting created successfully");
                 window.location.href = "/jobs"; // Redirect to a jobs page
@@ -54,6 +98,5 @@ const createJobEntry = () => {
             }
         }
     });
-
     return false;
 }

--- a/fosa_connect/www/post_job/index.py
+++ b/fosa_connect/www/post_job/index.py
@@ -1,0 +1,16 @@
+import frappe
+import json
+from frappe.utils.file_manager import save_file
+
+@frappe.whitelist()
+def upload_file(filedata, doc_name):
+    doc = frappe.get_doc('Job', doc_name)
+    if filedata:
+        filedata_json = json.loads(filedata)
+        filedata_list = list(filedata_json["files_data"])
+        for filedata_item in filedata_list:
+            filedoc = save_file(filedata_item["filename"], filedata_item["dataurl"], doc.doctype, doc.name, decode=True, is_private=0, df='job_details')
+            doc.job_details = filedoc.file_url
+            doc.save()
+            #Only One file will be there
+            return 1


### PR DESCRIPTION
## Feature description
Added feature to upload job details file while posting jobs

## Solution description

- Alumni can now upload job details file(eg. PDF) to provide detailed info about the job
- Added field to job doctype for storing file

## Output screenshots
![image](https://github.com/efeone/fosa_connect/assets/59536246/1f8e76a4-3061-4184-aded-66892acbce35)
![image](https://github.com/efeone/fosa_connect/assets/59536246/3c4c49d1-936d-4e57-83c4-f731e49eb72d)


## Areas affected and ensured
Job

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox