### PR TITLE
Add fields in job doctype

### DIFF
--- a/fosa_connect/fosa_connect/doctype/job/job.json
+++ b/fosa_connect/fosa_connect/doctype/job/job.json
@@ -116,10 +116,8 @@
    "fieldname": "job_details",
    "fieldtype": "Attach",
    "label": "Job Details"
-  }
- ],
- "links": [],
- "modified": "2023-12-05 12:59:18.646065",
+ },
+ {
    "fieldname": "organization_type",
    "fieldtype": "Link",
    "label": "Organization Type",

--- a/fosa_connect/fosa_connect/doctype/job/job.json
+++ b/fosa_connect/fosa_connect/doctype/job/job.json
@@ -12,7 +12,7 @@
   "published",
   "job_title",
   "qualification",
-  "responsibility",
+  "organization_website",
   "start_date",
   "job_description",
   "job_details",
@@ -23,7 +23,8 @@
   "job_type",
   "last_date_to_apply",
   "salary_info",
-  "organization_name"
+  "organization_name",
+  "organization_type"
  ],
  "fields": [
   {
@@ -80,16 +81,10 @@
    "reqd": 1
   },
   {
-   "fieldname": "responsibility",
-   "fieldtype": "Data",
-   "label": "Responsibility",
-   "reqd": 1
-  },
-  {
    "fieldname": "job_type",
    "fieldtype": "Select",
    "label": "Job Type",
-   "options": "Full-Time\nPart-Time"
+   "options": "Full-Time\nPart-Time\nInternship"
   },
   {
    "default": "0",
@@ -125,6 +120,20 @@
  ],
  "links": [],
  "modified": "2023-12-05 12:59:18.646065",
+   "fieldname": "organization_type",
+   "fieldtype": "Link",
+   "label": "Organization Type",
+   "options": "Organization Type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "organization_website",
+   "fieldtype": "Data",
+   "label": "Organization Website"
+  }
+ ],
+ "links": [],
+ "modified": "2023-12-05 16:52:17.777533",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Job",

--- a/fosa_connect/fosa_connect/doctype/job/job.py
+++ b/fosa_connect/fosa_connect/doctype/job/job.py
@@ -35,12 +35,12 @@ def permission_query_conditions(user):
     return None
 
 @frappe.whitelist()
-def post_job(job_title, qualification, responsibility, start_date, end_date, job_category, location, job_type, salary_info, job_description, organization, isPublished):
-    job_data = { 
+def post_job(job_title, qualification, organization_website, start_date, end_date, job_category, location, job_type, salary_info, job_description, organization, organization_type,isPublished):
+    job_data = {
         "doctype": "Job",
         "job_title": job_title,
         "qualification": qualification,
-        "responsibility": responsibility,
+        "organization_website": organization_website,
         "start_date": start_date,
         "last_date_to_apply": end_date,
         "job_category": job_category,
@@ -49,6 +49,7 @@ def post_job(job_title, qualification, responsibility, start_date, end_date, job
         "salary_info": salary_info,
         "job_description": job_description,
         "organization_name": organization,
+        "organization_type": organization_type,
         "published" : isPublished
     }
     job_doc = frappe.get_doc(job_data)

--- a/fosa_connect/fosa_connect/doctype/organization_type/organization_type.js
+++ b/fosa_connect/fosa_connect/doctype/organization_type/organization_type.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Organization Type', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/fosa_connect/fosa_connect/doctype/organization_type/organization_type.json
+++ b/fosa_connect/fosa_connect/doctype/organization_type/organization_type.json
@@ -1,0 +1,62 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:organization_type",
+ "creation": "2023-12-05 14:07:09.076119",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "organization_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "organization_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Organization Type",
+   "reqd": 1,
+   "unique": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2023-12-06 10:50:15.466321",
+ "modified_by": "Administrator",
+ "module": "FOSA Connect",
+ "name": "Organization Type",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Alumni",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/fosa_connect/fosa_connect/doctype/organization_type/organization_type.py
+++ b/fosa_connect/fosa_connect/doctype/organization_type/organization_type.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class OrganizationType(Document):
+	pass

--- a/fosa_connect/fosa_connect/doctype/organization_type/test_organization_type.py
+++ b/fosa_connect/fosa_connect/doctype/organization_type/test_organization_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestOrganizationType(FrappeTestCase):
+	pass

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -226,6 +226,7 @@ fixtures = [{"dt": "Program"},
 			{"dt": "Workflow State"},
 			{"dt": "Email Template"},
 			{"dt": "Qualification"},
+			{"dt": "Organization Type"},
 			{'dt': 'Role', 'filters': [['name', 'in', ['Student','Alumni','Placement Officer']]]},
 			{"dt": "Custom DocPerm", "filters": [['parent', 'in', ['Address','Contact', 'User','Workflow']]]}
 

--- a/fosa_connect/www/edit_job/index.css
+++ b/fosa_connect/www/edit_job/index.css
@@ -126,7 +126,7 @@
       margin-top: 1em;
       font-family: 'Merriweather', sans-serif;
       box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
-      resize: none; 
+      resize: none;
     }
     #input-qualification{
       border: 0;
@@ -157,13 +157,26 @@
       box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
       resize: none;
     }
-
+    #input-organization_type{
+      border: 0;
+      outline: 0;
+      padding: 1em;
+      border-radius: 12px;
+      background: #ffffff;
+      display: block;
+      color:#000000;
+      width: 92%;
+      margin-top: 1em;
+      font-family: 'Merriweather', sans-serif;
+      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+      resize: none;
+    }
     label{
       display: inline-block;
       margin-bottom: -0.5rem;
       margin-top: 10px;
      }
-     
+
      input[type="checkbox"]{
 
       margin-left: 70px;

--- a/fosa_connect/www/edit_job/index.html
+++ b/fosa_connect/www/edit_job/index.html
@@ -1,6 +1,7 @@
 {% extends "templates/base.html" %}
 {% set catgry_doc = frappe.get_all('Job Category', fields=['job_category']) %}
 {% set qualification_doc = frappe.get_all('Qualification', fields=['qualification']) %}
+{% set orgtype_doc = frappe.get_all('Organization Type',fields=['organization_type']) %}
 {% set job_doc = frappe.get_doc('Job', job_id) %}
 {%- block content -%}
 
@@ -15,11 +16,11 @@
             <option value="{{ qualify.qualification }}" {% if qualify.qualification == job_doc.qualification %}selected{% endif %}>{{ qualify.qualification }}</option>
         {%- endfor -%}
     </select>
-    
-    
-      <input type="text" id="input-responsibility" value="{{ job_doc.responsibility }}" placeholder="Responsibility">
+
+
+      <input type="text" id="input-organization_website" value="{{ job_doc.organization_website }}" placeholder="Organization Website">
       &nbsp;
-      <label for="start-date" class="fonds">Start Date:</label>
+      <label for="start-date" class="fonds">Post Date:</label>
       <input type="date" id="start-date" value="{{ job_doc.start_date }}">
       &nbsp;
       <label for="end-date" class="fonds">End Date:</label>
@@ -33,15 +34,22 @@
             <option value="{{ category.job_category }}" {% if category.job_category == job_doc.job_category %}selected{% endif %}>{{ category.job_category }}</option>
         {%- endfor -%}
     </select>
-    
+
       <input type="text" id="input-location" value="{{ job_doc.location }}" placeholder="Location">
       <select id="input-type">
         <option value="" disabled selected>Job-Type</option>
         <option value="Full-Time" {% if job_doc.job_type == 'Full-Time' %}selected{% endif %}>Full-Time</option>
         <option value="Part-Time" {% if job_doc.job_type == 'Part-Time' %}selected{% endif %}>Part-Time</option>
+        <option value="Internship" {% if job_doc.job_type == 'Internship' %}selected{% endif %}>Internship</option>
       </select>
       <input type="text" id="input-salary" value="{{ job_doc.salary_info }}" placeholder="Salary">
       <input type="text" id="input-organization" value="{{ job_doc.organization_name}}" placeholder="Organization">
+      <select id="input-organization_type">
+        <option value="" disabled>Organization Type</option>
+        {%- for org in orgtype_doc-%}
+            <option value="{{ org.organization_type }}" {% if org.organization_type == job_doc.organization_type %}selected{% endif %}>{{org.organization_type}}</option>
+        {%- endfor -%}
+    </select>
     </div>
     <div>
       <textarea class="message" name="message" id="input-message" placeholder="Job Description">{{ job_doc.job_description }}</textarea>
@@ -50,7 +58,7 @@
       <label for="isPublished">Publish</label>
       <input type="checkbox" id="isPublished" name="isPublished" value="1" {% if job_doc.published %}checked{% endif %}>
     </div>
-    
+
     <div class="button-container">
       <button class="submit" type="submit" value="Submit" id="input-submit">Save</button>
     </div>

--- a/fosa_connect/www/edit_job/index.js
+++ b/fosa_connect/www/edit_job/index.js
@@ -19,7 +19,7 @@ const EditJobEntry = (job_id, isPublished, disabled) => {
   // Get values from form fields
   let title = $("#input-title").val().trim();
   let qualification = $("#input-qualification").val().trim();
-  let responsibility = $("#input-responsibility").val().trim();
+  let organization_website = $("#input-organization_website").val().trim();
   let start_date = $("#start-date").val().trim();
   let end_date = $("#end-date").val().trim();
   let category = $("#input-category").val().trim();
@@ -28,6 +28,7 @@ const EditJobEntry = (job_id, isPublished, disabled) => {
   let salary = $("#input-salary").val().trim();
   let message = $("#input-message").val().trim();
   let organization = $("#input-organization").val().trim();
+  let organization_type = $("#input-organization_type").val().trim();
 
   // Update edited job posting entry
   frappe.call({
@@ -36,7 +37,7 @@ const EditJobEntry = (job_id, isPublished, disabled) => {
       "job_id": job_id,
       "job_title": title,
       "qualification": qualification,
-      "responsibility": responsibility,
+      "organization_website": organization_website,
       "start_date": start_date,
       "end_date": end_date,
       "job_category": category,
@@ -46,7 +47,9 @@ const EditJobEntry = (job_id, isPublished, disabled) => {
       "job_description": message,
       "organization": organization,
       "isPublished": isPublished,  // Update 'isPublished' with the new value
-      "disabled": disabled
+      "disabled": disabled,
+      "organization_type": organization_type
+
     },
     callback: function (response) {
       if (response.message) {

--- a/fosa_connect/www/edit_job/index.py
+++ b/fosa_connect/www/edit_job/index.py
@@ -6,11 +6,11 @@ def get_context(context):
     context.job_id = job_id
 
 @frappe.whitelist()
-def edit_job(job_id, job_title, qualification, responsibility, start_date, end_date, job_category, location, job_type, salary_info, job_description, organization, isPublished, disabled):
+def edit_job(job_id, job_title, qualification, organization_website, start_date, end_date, job_category, location, job_type, salary_info, job_description, organization, organization_type, isPublished,disabled):
     job=frappe.get_doc("Job",job_id)
     job.job_title = job_title
     job.qualification = qualification
-    job.responsibility = responsibility
+    job.organization_website = organization_website
     job.start_date = start_date
     job.last_date_to_apply = end_date
     job.job_category = job_category
@@ -19,6 +19,7 @@ def edit_job(job_id, job_title, qualification, responsibility, start_date, end_d
     job.salary_info = salary_info
     job.job_description = job_description
     job.organization_name = organization
+    job.organization_type = organization_type
     job.published = isPublished
     job.disabled = disabled
     job.save()

--- a/fosa_connect/www/jobs/job.html
+++ b/fosa_connect/www/jobs/job.html
@@ -28,8 +28,8 @@
                 {%- endif -%}
             {%- endif -%}
         </div>
-        
-          
+
+
         </div>
       </div>
     </div>
@@ -48,8 +48,10 @@
       <div class="col-md-6">
         <p><i class="fas fa-calendar-day"></i> Last date to apply: {{ jobs.get_formatted("last_date_to_apply") }} </p>
         <h4><i class="fas fa-folder"></i> Job Category: {{ jobs.job_category }}</h4>
-        <p><i class="fas fa-tasks"></i> Responsibility: {{ jobs.responsibility }} </p>
         <p><i class="fas fa-graduation-cap"></i> Qualification: {{ jobs.qualification }} </p>
+        <p><i class="fas fa-globe"></i> Organization Website: {{ jobs.organization_website }} </p>
+        <p><i class="fas fa-building"></i> Organization Type: {{ jobs.organization_type }} </p>
+
       </div>
     </div>
     <hr>

--- a/fosa_connect/www/post_job/index.css
+++ b/fosa_connect/www/post_job/index.css
@@ -127,7 +127,7 @@
       margin-top: 1em;
       font-family: 'Merriweather', sans-serif;
       box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
-      resize: none; 
+      resize: none;
     }
     #input-qualification{
       border: 0;
@@ -138,6 +138,21 @@
       display: block;
       color:#000000;
       width: 92%;
+      margin-top: 1em;
+      font-family: 'Merriweather', sans-serif;
+      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+      resize: none;
+
+    }
+    #input-organization_type{
+      border: 0;
+      outline: 0;
+      padding: 1em;
+      border-radius: 12px;
+      background: #ffffff;
+      display: block;
+      color:#000000;
+      width: 45%;
       margin-top: 1em;
       font-family: 'Merriweather', sans-serif;
       box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
@@ -164,7 +179,7 @@
       margin-bottom: -0.5rem;
       margin-top: 10px;
      }
-     
+
 
     input[type="checkbox"]{
 

--- a/fosa_connect/www/post_job/index.html
+++ b/fosa_connect/www/post_job/index.html
@@ -1,6 +1,7 @@
 {% extends "templates/base.html" %}
 {% set catgry_doc = frappe.get_all('Job Category',fields=['job_category']) %}
 {% set qualification_doc = frappe.get_all('Qualification',fields=['qualification']) %}
+{% set orgtype_doc = frappe.get_all('Organization Type',fields=['organization_type']) %}
 {%- block content -%}
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
@@ -15,9 +16,9 @@
             <option value="{{ qualify.qualification }}">{{ qualify.qualification  }}</option>
           {%- endfor -%}
       </select>
-      <input type="text" id="input-responsibility" placeholder="Responsibility">
+      <input type="text" id="input-organization_website" placeholder="Organization Website">
       &nbsp;
-      <label for="start-date" class="fonds">Start Date:</label>
+      <label for="start-date" class="fonds">Post Date:</label>
       <input type="date" id="start-date" placeholder="start-date">
       &nbsp;
       <label for="end-date" class="fonds">End Date:</label>
@@ -36,11 +37,18 @@
         <option value="" disabled selected>Job-Type</option>
         <option value="Full-Time">Full-Time</option>
         <option value="Part-Time">Part-Time</option>
+        <option value="Internship">Internship</option>
     </select>
 
       <input type="text" id="input-salary" placeholder="Salary">
       <input type="text" id="input-organization"  placeholder="Organization">
     </div>
+    <select id="input-organization_type">
+      <option value="" disabled selected>Organization Type</option>
+        {%- for org in orgtype_doc -%}
+          <option value="{{org.organization_type }}">{{ org.organization_type }}</option>
+        {%- endfor -%}
+    </select>
     <div>
       <textarea class="message" name="message" type="text" id="input-message" placeholder="Job Description"></textarea>
     </div>

--- a/fosa_connect/www/post_job/index.js
+++ b/fosa_connect/www/post_job/index.js
@@ -39,7 +39,7 @@ const createJobEntry = () => {
     // Get values from form fields
     let title = $("#input-title").val().trim() || '';
     let qualification = $("#input-qualification").val().trim() || '';
-    let responsibility = $("#input-responsibility").val().trim() || '';
+    let organization_website = $("#input-organization_website").val().trim() || '';
     let start_date = $("#start-date").val().trim() || '';
     let end_date = $("#end-date").val().trim() || '';
     let category = $("#input-category").val().trim() || '';
@@ -48,7 +48,9 @@ const createJobEntry = () => {
     let salary = $("#input-salary").val().trim() || '';
     let message = $("#input-message").val().trim() || '';
     let organization = $("#input-organization").val().trim() || '';
+    let organization_type = $("#input-organization_type").val().trim() || '';
     let docName;
+
     // Create a new job posting entry
     frappe.call({
         method: "fosa_connect.fosa_connect.doctype.job.job.post_job",
@@ -56,7 +58,7 @@ const createJobEntry = () => {
         args: {
             "job_title": title,
             "qualification": qualification,
-            "responsibility": responsibility,
+            "organization_website": organization_website,
             "start_date": start_date,
             "end_date": end_date,
             "job_category": category,
@@ -64,8 +66,9 @@ const createJobEntry = () => {
             "job_type": type,
             "salary_info": salary,
             "job_description": message,
-            "organization": organization,
-            "isPublished": isPublished
+            "organization" : organization,
+            "isPublished" : isPublished,
+            "organization_type" : organization_type
         },
         callback: function (response) {
             if (response.message) {


### PR DESCRIPTION
## Feature description
Add new fields, 'Organization Type' and 'Organization Website,' to the 'Job' doctype,post job and edit job.  Additionally, include the option 'Internship' in the 'Job Type' field.
Remove Responsibility field from jobdoctype.

## Solution description
Add Fields to Job Doctype:
    Introduce two new fields in the "Job" doctype:
        Field 1: "Organization Type" 
        Field 2: "Organization Website" 
Update Job Type Options:
    Expand the options available in the "Job Type" field to include:
        Option: "Internship" 

## Output screensh
![Screenshot from 2023-12-06 12-19-59](https://github.com/efeone/fosa_connect/assets/84180042/81273992-0b96-495e-8592-af67debdf63f)



## Areas affected and ensured
Job Doctype,Post Job,Edit job

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 