### PR TITLE
feat:Set alumni as member approver.

### DIFF
--- a/fosa_connect/fosa_connect/doctype/batch/batch.js
+++ b/fosa_connect/fosa_connect/doctype/batch/batch.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Batch', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/fosa_connect/fosa_connect/doctype/batch/batch.json
+++ b/fosa_connect/fosa_connect/doctype/batch/batch.json
@@ -1,0 +1,46 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:batch",
+ "creation": "2024-01-31 14:44:18.525308",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "batch"
+ ],
+ "fields": [
+  {
+   "fieldname": "batch",
+   "fieldtype": "Data",
+   "label": "Batch",
+   "unique": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-01-31 14:46:07.941541",
+ "modified_by": "Administrator",
+ "module": "FOSA Connect",
+ "name": "Batch",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/fosa_connect/fosa_connect/doctype/batch/batch.py
+++ b/fosa_connect/fosa_connect/doctype/batch/batch.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class Batch(Document):
+	pass

--- a/fosa_connect/fosa_connect/doctype/batch/test_batch.py
+++ b/fosa_connect/fosa_connect/doctype/batch/test_batch.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBatch(FrappeTestCase):
+	pass

--- a/fosa_connect/fosa_connect/doctype/member/member.json
+++ b/fosa_connect/fosa_connect/doctype/member/member.json
@@ -23,8 +23,10 @@
   "year_of_admission",
   "column_break_opage",
   "department",
+  "university_member_id",
   "details_section",
   "year_of_passing",
+  "batch",
   "organization",
   "column_break_lqgb5",
   "job_title",
@@ -302,12 +304,23 @@
    "label": "Status",
    "options": "Pending Approval\nActive\nDisabled",
    "read_only": 1
+  },
+  {
+   "fieldname": "university_member_id",
+   "fieldtype": "Data",
+   "label": "University Registeration No."
+  },
+  {
+   "fieldname": "batch",
+   "fieldtype": "Link",
+   "label": "Batch",
+   "options": "Batch"
   }
  ],
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-01-10 15:04:00.284096",
+ "modified": "2024-02-01 14:33:25.564983",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Member",
@@ -359,6 +372,18 @@
    "read": 1,
    "report": 1,
    "role": "Placement Officer",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Member Approver",
    "share": 1,
    "write": 1
   }

--- a/fosa_connect/fosa_connect/doctype/member/member_list.js
+++ b/fosa_connect/fosa_connect/doctype/member/member_list.js
@@ -1,0 +1,41 @@
+frappe.listview_settings['Member'] = {
+  refresh: function(frm) {
+    frm.page.add_inner_button(__("Add Approver"), function () {
+      let d = new frappe.ui.Dialog({
+      title: 'Enter details',
+      fields: [
+          {
+              label: 'Member',
+              fieldname: 'member',
+              fieldtype: 'Link',
+              options: 'Member'
+          },
+          {
+              label: 'Batch',
+              fieldname: 'batch',
+              fieldtype: 'Link',
+              options: 'Batch'
+          }
+      ],
+      size: 'small', // small, large, extra-large
+      primary_action_label: 'Submit',
+      primary_action(values) {
+        frappe.call({
+          method:'fosa_connect.fosa_connect.doctype.member.member.create_user_permission',
+          args: {
+            'user_permission':values
+          },
+          callback: function(r){
+            if(r.message){
+              d.hide();
+            }
+          }
+        })
+      }
+    });
+
+    d.show();
+
+    });
+  }
+}

--- a/fosa_connect/www/update_profile/index.html
+++ b/fosa_connect/www/update_profile/index.html
@@ -263,6 +263,28 @@
               </div>
             </div>
             {% endif %}
+            <div class="input-column" style="margin-left: -25px;">
+              <div class="input-fields">
+                <label class="input-label">University Registration ID</label>
+                <input type="text" placeholder="Please enter your university registration id" class="input" id="university_registration_id"
+                  name="University Registration ID"
+                  value="{{ member.university_registration_id or '' }}"required />
+              </div>
+            </div>
+            <div class="input-column" style="margin-left: -25px;">
+              <div class="input-fields" style="margin-left: -32px;">
+                <label class="input-label">Batch</label>
+                <input type="text" placeholder="Please enter your batch" class="input" id="batch" name="Batch"
+                  value="{{member.batch or ''}}" readonly />
+              </div>
+            </div>
+              <div class="input-column">
+                <div class="input-fields">
+                  <label class="input-label"></label>
+                  <input class="none" id="mobile_no"
+                  />
+                </div>
+              </div>
             <div class="input-column">
               <div class="input-fields">
                 <label class="input-label">LinkedIn</label>


### PR DESCRIPTION
## Feature description
Add a University registration id and batch field in member doctype and this field in member webpage.
The placement officer can grant permission to alumni as member approvers, and alumni can only approve members from their own batch.

## Solution description
1.Add an 'Add Approver' button on the member page.
2 Add a 'batch' field in member doctype.
3.Batch-wise, the placement officer can grant alumni permission to approve members of their batch. When the 'Add Approver' button is clicked, a dialogue box appears to select a member and batch. Upon submission, user permission is created.


## Areas affected and ensured
Member

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?

  - Mozilla Firefox
  