### PR TITLE
implement Member Approver role for alumni allowing approval of members.

### DIFF
--- a/fosa_connect/fosa_connect/doctype/batch/batch.js
+++ b/fosa_connect/fosa_connect/doctype/batch/batch.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Batch', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/fosa_connect/fosa_connect/doctype/batch/batch.json
+++ b/fosa_connect/fosa_connect/doctype/batch/batch.json
@@ -1,0 +1,46 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:batch",
+ "creation": "2024-01-31 14:44:18.525308",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "batch"
+ ],
+ "fields": [
+  {
+   "fieldname": "batch",
+   "fieldtype": "Data",
+   "label": "Batch",
+   "unique": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-01-31 14:46:07.941541",
+ "modified_by": "Administrator",
+ "module": "FOSA Connect",
+ "name": "Batch",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/fosa_connect/fosa_connect/doctype/batch/batch.py
+++ b/fosa_connect/fosa_connect/doctype/batch/batch.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class Batch(Document):
+	pass

--- a/fosa_connect/fosa_connect/doctype/batch/test_batch.py
+++ b/fosa_connect/fosa_connect/doctype/batch/test_batch.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBatch(FrappeTestCase):
+	pass

--- a/fosa_connect/fosa_connect/doctype/member/member.json
+++ b/fosa_connect/fosa_connect/doctype/member/member.json
@@ -23,14 +23,16 @@
   "year_of_admission",
   "column_break_opage",
   "department",
-  "university_member_id",
   "details_section",
   "year_of_passing",
-  "batch",
   "organization",
   "column_break_lqgb5",
   "job_title",
   "designation",
+  "section_break_bde60",
+  "batch",
+  "column_break_pasec",
+  "university_member_id",
   "profile_tab",
   "primary_address",
   "address_html",
@@ -315,12 +317,20 @@
    "fieldtype": "Link",
    "label": "Batch",
    "options": "Batch"
+  },
+  {
+   "fieldname": "section_break_bde60",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_pasec",
+   "fieldtype": "Column Break"
   }
  ],
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-02-01 14:33:25.564983",
+ "modified": "2024-02-03 15:24:01.914423",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Member",

--- a/fosa_connect/fosa_connect/doctype/member/member.json
+++ b/fosa_connect/fosa_connect/doctype/member/member.json
@@ -23,8 +23,10 @@
   "year_of_admission",
   "column_break_opage",
   "department",
+  "university_member_id",
   "details_section",
   "year_of_passing",
+  "batch",
   "organization",
   "column_break_lqgb5",
   "job_title",
@@ -302,12 +304,23 @@
    "label": "Status",
    "options": "Pending Approval\nActive\nDisabled",
    "read_only": 1
+  },
+  {
+   "fieldname": "university_member_id",
+   "fieldtype": "Data",
+   "label": "University Registeration No."
+  },
+  {
+   "fieldname": "batch",
+   "fieldtype": "Link",
+   "label": "Batch",
+   "options": "Batch"
   }
  ],
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-01-10 15:04:00.284096",
+ "modified": "2024-02-01 14:33:25.564983",
  "modified_by": "Administrator",
  "module": "FOSA Connect",
  "name": "Member",
@@ -359,6 +372,18 @@
    "read": 1,
    "report": 1,
    "role": "Placement Officer",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Member Approver",
    "share": 1,
    "write": 1
   }

--- a/fosa_connect/fosa_connect/doctype/member/member_list.js
+++ b/fosa_connect/fosa_connect/doctype/member/member_list.js
@@ -1,0 +1,41 @@
+frappe.listview_settings['Member'] = {
+  refresh: function(frm) {
+    frm.page.add_inner_button(__("Add Approver"), function () {
+      let d = new frappe.ui.Dialog({
+      title: 'Enter details',
+      fields: [
+          {
+              label: 'Member',
+              fieldname: 'member',
+              fieldtype: 'Link',
+              options: 'Member'
+          },
+          {
+              label: 'Batch',
+              fieldname: 'batch',
+              fieldtype: 'Link',
+              options: 'Batch'
+          }
+      ],
+      size: 'small', // small, large, extra-large
+      primary_action_label: 'Submit',
+      primary_action(values) {
+        frappe.call({
+          method:'fosa_connect.fosa_connect.doctype.member.member.create_user_permission',
+          args: {
+            'user_permission':values
+          },
+          callback: function(r){
+            if(r.message){
+              d.hide();
+            }
+          }
+        })
+      }
+    });
+
+    d.show();
+
+    });
+  }
+}

--- a/fosa_connect/fosa_connect/overrides.py
+++ b/fosa_connect/fosa_connect/overrides.py
@@ -6,7 +6,7 @@ from frappe.desk.form.assign_to import add as add_assign
 from frappe.utils.user import get_users_with_role
 
 @frappe.whitelist(allow_guest=True)
-def sign_up(email, first_name, last_name, full_name,  member_type, admission_number=None, year_of_admission=None, department=None, year_of_passing=None, job_title=None, organization=None):
+def sign_up(email, first_name, last_name, full_name,  member_type, admission_number=None, year_of_admission=None, department=None, year_of_passing=None, batch=None, job_title=None, organization=None):
     if is_signup_disabled():
         frappe.throw(_('Sign Up is disabled'), title='Not Allowed')
 
@@ -38,7 +38,7 @@ def sign_up(email, first_name, last_name, full_name,  member_type, admission_num
     user.insert(ignore_permissions=True)
 
 
-    create_member(email, first_name, last_name, member_type,admission_number, year_of_admission, department, year_of_passing, job_title, organization)
+    create_member(email, first_name, last_name, member_type,admission_number, year_of_admission, department, year_of_passing, batch, job_title, organization)
 
     if user.flags.email_sent:
         return 1, _("Please check your email for verification")
@@ -47,7 +47,7 @@ def sign_up(email, first_name, last_name, full_name,  member_type, admission_num
 
 
 @frappe.whitelist(allow_guest=True)
-def create_member(email, first_name, last_name, member_type, admission_number=None, year_of_admission=None, department=None, year_of_passing=None, job_title=None, organization=None):
+def create_member(email, first_name, last_name, member_type, admission_number=None, year_of_admission=None, department=None, year_of_passing=None, batch=None, job_title=None, organization=None):
     if frappe.db.exists('Member', { 'email': email }):
         frappe.throw('Member already registered with this email id.')
     else:
@@ -69,6 +69,7 @@ def create_member(email, first_name, last_name, member_type, admission_number=No
             "year_of_passing": year_of_passing if member_type == "Alumni" else "",
             "job_title": job_title if member_type == "Alumni" else "",
             "organization": organization if member_type == "Alumni" else "",
+            "batch": batch,
         }
 
         member = frappe.get_doc(member_data)

--- a/fosa_connect/hooks.py
+++ b/fosa_connect/hooks.py
@@ -221,6 +221,7 @@ doc_events = {
 # ]
 
 fixtures = [{"dt": "Program"},
+			{"dt": "Batch"},
 			{"dt": "Job Category"},
 			{"dt": "Workflow"},
 			{"dt": "Workflow State"},

--- a/fosa_connect/templates/signup_form.html
+++ b/fosa_connect/templates/signup_form.html
@@ -1,4 +1,5 @@
 {% set dept_doc = frappe.get_all('Program',fields=["program_name"]) %}
+{% set batch_doc = frappe.get_all('Batch',fields=["batch"]) %}
 <form class="signup-form signup-form-fosa" role="form" id="signup-form">
     <div class="page-card-body">
         <div class="form-group">
@@ -47,7 +48,7 @@
                     required
                 >
             </div>
-           
+
         </div>
         <div id="Student_fields">
             <div class="form-group">
@@ -69,6 +70,21 @@
                     placeholder="{{ _('Year of Admission') }}"
                     required
                 >
+            </div>
+            <div class="form-group">
+                <label class="form-label sr-only" for="batch"></label>
+                <select
+                    id="batch-select"
+                    name="batch"
+                    class="form-control"
+                    style="background-color: var(--control-bg);"
+                    required
+                >
+                    <option value="">Select Batch</option>
+                    {%- for batch in batch_doc -%}
+                    <option value="{{ batch.batch }}">{{ batch.batch}}</option>
+                    {%- endfor -%}
+                </select>
             </div>
             <div class="form-group">
                 <label class="form-label sr-only" for="department"></label>
@@ -96,6 +112,21 @@
                     placeholder="{{ _('Year of Passing') }}"
                     required
                 >
+            </div>
+            <div class="form-group">
+                <label class="form-label sr-only" for="batch"></label>
+                <select
+                    id="batch-select"
+                    name="batch"
+                    class="form-control"
+                    style="background-color: var(--control-bg);"
+                    required
+                >
+                    <option value="">Select Batch</option>
+                    {%- for batch in batch_doc -%}
+                    <option value="{{ batch.batch }}">{{ batch.batch}}</option>
+                    {%- endfor -%}
+                </select>
             </div>
             <div class="form-group">
                 <label class="form-label sr-only" for="job_title">{{ _("Job Title") }}</label>
@@ -148,6 +179,7 @@
           let year_of_admission = frappe.utils.xss_sanitise($("#year_of_admission").val() || "").trim();
           let department = frappe.utils.xss_sanitise($("#department-select").val() || "").trim();
           let year_of_passing = frappe.utils.xss_sanitise($("#year_of_passing").val() || "").trim();
+          let batch = frappe.utils.xss_sanitise($("#batch-select").val() || "").trim();
           let job_title = frappe.utils.xss_sanitise($("#job_title").val() || "").trim();
           let organization = frappe.utils.xss_sanitise($("#organization").val() || "").trim();
 
@@ -161,6 +193,7 @@
                   "last_name": last_name,
                   "full_name": full_name,
                   "year_of_passing": year_of_passing,
+                  "batch": batch,
                   "job_title": job_title,
                   "organization": organization,
                   "member_type": memberType,
@@ -202,6 +235,7 @@
       document.getElementById('year_of_admission').value = '';
       document.getElementById('department-select').value = '';
       document.getElementById('year_of_passing').value = '';
+      document.getElementById('batch-select').value = '';
       document.getElementById('job_title').value = '';
       document.getElementById('organization').value = '';
       document.getElementById('General_fields').style.display = 'none';

--- a/fosa_connect/www/update_profile/index.html
+++ b/fosa_connect/www/update_profile/index.html
@@ -263,6 +263,28 @@
               </div>
             </div>
             {% endif %}
+            <div class="input-column" style="margin-left: -25px;">
+              <div class="input-fields">
+                <label class="input-label">University Registration ID</label>
+                <input type="text" placeholder="Please enter your university registration id" class="input" id="university_registration_id"
+                  name="University Registration ID"
+                  value="{{ member.university_registration_id or '' }}"required />
+              </div>
+            </div>
+            <div class="input-column" style="margin-left: -25px;">
+              <div class="input-fields" style="margin-left: -32px;">
+                <label class="input-label">Batch</label>
+                <input type="text" placeholder="Please enter your batch" class="input" id="batch" name="Batch"
+                  value="{{member.batch or ''}}" readonly />
+              </div>
+            </div>
+              <div class="input-column">
+                <div class="input-fields">
+                  <label class="input-label"></label>
+                  <input class="none" id="mobile_no"
+                  />
+                </div>
+              </div>
             <div class="input-column">
               <div class="input-fields">
                 <label class="input-label">LinkedIn</label>


### PR DESCRIPTION
## Feature description
1.Add a University registration id and batch field in member doctype and this field in member webpage.
2.The placement officer can grant permission to alumni as member approvers, and alumni can only approve members from their own batch.
3.Add a "Batch" field to the signup page for both alumni and students.
4.Retrieve the value of the batch on the member page.

## Solution description
1.Add an 'Add Approver' button on the member page.
2 Add a 'batch' field in member doctype.
3.Batch-wise, the placement officer can grant alumni permission to approve members of their batch. When the 'Add Approver' button is clicked, a dialogue box appears to select a member and batch. Upon submission, user permission is created.
4. "Batch" is a master doctype; add this field to both the alumni and student signup pages.
5. Provide the appropriate section break and place both the University Registration ID and Batch in the correct locations within the doctype.

## Output screenshots (optional)
![Screenshot from 2024-02-03 16-07-28](https://github.com/efeone/fosa_connect/assets/84180042/8ca82858-e19b-4578-a896-f3c080ff03a1)

[Screencast from 03-02-24 04:32:14 PM IST.webm](https://github.com/efeone/fosa_connect/assets/84180042/6c1d1d60-ccf4-4318-9286-82b321d13d2a)

## Areas affected and ensured
Member
Signup Page

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
